### PR TITLE
Log in prod to syslog

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -1,10 +1,9 @@
 monolog:
     handlers:
-        main:
+        main_logfile:
             type: stream
             path: '%kernel.logs_dir%/%kernel.environment%.log'
-            level: debug
-            channels: ['!event']
+            level: NOTICE
         console:
             type: console
             process_psr_3_messages: false

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -13,7 +13,7 @@ framework:
     #esi: true
     fragments: true
     php_errors:
-        log: true
+        log: "%kernel.debug%"
     templating:
         engines:
             - twig

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -1,13 +1,16 @@
 monolog:
     handlers:
-        main:
+        prod-signaler:
             type: fingers_crossed
-            action_level: error
-            handler: nested
-        nested:
-            type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
-            level: debug
+            action_level: ERROR
+            passthru_level: NOTICE # this means that all message of level NOTICE or higher are always logged
+            handler: main_syslog
+            bubble: false # if we handle it, nothing else should
+        main_syslog:
+            type: syslog
+            ident: stepup-webauthn
+            facility: user
+            formatter: surfnet_stepup.monolog.json_formatter
         console:
             type: console
             process_psr_3_messages: false

--- a/config/packages/test/monolog.yaml
+++ b/config/packages/test/monolog.yaml
@@ -1,7 +1,12 @@
 monolog:
     handlers:
-        main:
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
-            channels: ["!event"]
+        # Handlers are merged in from config.yml and config_dev.yml. They cannot be disabled or removed. The practical
+        # solution is to assign them the `null` handler, which discards the records.
+        prod-signaler:
+            type: "null"
+        main_syslog:
+            type: "null"
+        main_logfile:
+            type: "null"
+        console:
+            type: "null"


### PR DESCRIPTION
In prod logging to disk was used, but that should've been
to syslog and is now changed.