### PR TITLE
Remove .env.dist from excludes in Composer Archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,6 @@
       "!/public/build",
       ".github",
       ".gitignore",
-      ".env.dist",
       ".travis.yml",
       ".travis.php.ini",
       "/symfony.lock",


### PR DESCRIPTION
I added that line in a cleanup attempt of the release tarbal. Turns out the deploy tasks relies on the .env.dist file to be present when installing the release.