### PR TITLE
Add .scrutinizer.yml with same checks as SelfService

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,143 @@
+build:
+  image: default-jammy
+  environment:
+    php: 8.2
+    node: v20
+  nodes:
+    analysis:
+      tests:
+        override:
+          - php-scrutinizer-run
+
+
+filter:
+  excluded_paths:
+    - "tests/*"
+
+checks:
+  php:
+    verify_property_names: true
+    verify_argument_usable_as_reference: true
+    verify_access_scope_valid: true
+    variable_existence: true
+    useless_calls: true
+    use_statement_alias_conflict: true
+    use_self_instead_of_fqcn: true
+    uppercase_constants: true
+    uppercase_basic_constants: false
+    unused_variables: true
+    unused_properties: true
+    unused_parameters: true
+    unused_methods: true
+    unreachable_code: true
+    too_many_arguments: true
+    symfony_request_injection: true
+    switch_fallthrough_commented: true
+    sql_injection_vulnerabilities: true
+    spacing_of_function_arguments: true
+    argument_type_checks: true
+    assignment_of_null_return: true
+    avoid_aliased_php_functions: true
+    avoid_closing_tag: true
+    avoid_conflicting_incrementers: true
+    avoid_corrupting_byteorder_marks: true
+    avoid_duplicate_types: true
+    avoid_entity_manager_injection: true
+    avoid_fixme_comments: true
+    avoid_length_functions_in_loops: true
+    avoid_multiple_statements_on_same_line: true
+    avoid_perl_style_comments: true
+    avoid_tab_indentation: true
+    avoid_superglobals: true
+    avoid_todo_comments: true
+    avoid_unnecessary_concatenation: true
+    avoid_usage_of_logical_operators: true
+    avoid_useless_overridden_methods: true
+    blank_line_after_namespace_declaration: true
+    catch_class_exists: true
+    classes_in_camel_caps: true
+    closure_use_modifiable: true
+    closure_use_not_conflicting: true
+    code_rating: true
+    deadlock_detection_in_loops: true
+    deprecated_code_usage: true
+    duplication: true
+    encourage_postdec_operator: true
+    encourage_shallow_comparison: false
+    encourage_single_quotes: true
+    ensure_lower_case_builtin_functions: true
+    foreach_traversable: true
+    foreach_usable_as_reference: true
+    function_body_start_on_new_line: true
+    function_in_camel_caps: true
+    instanceof_class_exists: true
+    line_length:
+      max_length: '120'
+    lowercase_basic_constants: true
+    lowercase_php_keywords: true
+    method_calls_on_non_object: true
+    missing_arguments: true
+    newline_at_end_of_file: true
+    no_commented_out_code: true
+    no_debug_code: true
+    no_duplicate_arguments: true
+    no_else_if_statements: true
+    no_empty_statements: true
+    no_error_suppression: true
+    no_eval: true
+    no_exit: true
+    no_global_keyword: true
+    no_goto: true
+    no_long_variable_names:
+      maximum: '30'
+    no_mixed_inline_html: true
+    no_non_implemented_abstract_methods: true
+    no_property_on_interface: true
+    no_short_method_names:
+      minimum: '3'
+    no_short_open_tag: true
+    no_space_around_object_operator: true
+    no_space_before_semicolon: true
+    no_space_inside_cast_operator: true
+    no_trailing_whitespace: true
+    no_trait_type_hints: true
+    no_underscore_prefix_in_methods: true
+    no_underscore_prefix_in_properties: true
+    no_unnecessary_final_modifier: true
+    no_unnecessary_function_call_in_for_loop: true
+    no_unnecessary_if: true
+    non_commented_empty_catch_block: true
+    one_class_per_file: true
+    optional_parameters_at_the_end: true
+    overriding_private_members: true
+    param_doc_comment_if_not_inferrable: true
+    parameter_doc_comments: true
+    parameter_non_unique: true
+    parameters_in_camelcaps: true
+    php5_style_constructor: true
+    phpunit_assertions: true
+    precedence_in_conditions: true
+    precedence_mistakes: true
+    prefer_sapi_constant: true
+    prefer_unix_line_ending: true
+    prefer_while_loop_over_for_loop: true
+    properties_in_camelcaps: true
+    property_assignments: true
+    psr2_class_declaration: true
+    psr2_control_structure_declaration: true
+    psr2_switch_declaration: true
+    require_braces_around_control_structures: true
+    require_php_tag_first: true
+    require_scope_for_methods: true
+    require_scope_for_properties: true
+    return_doc_comment_if_not_inferrable: true
+    return_doc_comments: true
+    scope_indentation:
+      spaces_per_level: '4'
+    security_vulnerabilities: true
+    side_effects_or_types: true
+    simplify_boolean_return: true
+    single_namespace_per_use: true
+    space_after_cast: true
+    spacing_around_conditional_operators: true
+    spacing_around_non_conditional_operators: true


### PR DESCRIPTION
This PR adds Scrutinizer as a statistical analysis tool to Stepup WebAuthn. It uses the same ruleset as https://github.com/OpenConext/Stepup-SelfService/blob/main/.scrutinizer.yml 