### PR TITLE
Fix doctrine mapping & add integration test that fails on invalid schema

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 SURFnet B.V.
+ * Copyright %regexp:\d{4}% SURFnet %regexp:(B.V.|bv)%
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,23 +4,17 @@ on: [pull_request]
 jobs:
   run-qa-tests:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: /var/www/html/
-    container:
-      image:  ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
-      volumes:
-        - .:/var/www/html
-
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Composer install
-        run: composer install
+      - name: Init environment
+        run: cd ci/docker && ./init.sh
 
       - name: Build frontend assets
         run: yarn && yarn encore production
 
       - name: Run QA tests
-        run: composer check
+        run: |
+            cd ci/docker && docker compose exec -T webauthn bash -c 'composer check'

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -1,7 +1,5 @@
 ---
 
-version: '3.7'
-
 services:
   haproxy:
     image: ghcr.io/openconext/openconext-basecontainers/haproxy26:latest
@@ -14,7 +12,7 @@ services:
           - "webauthn.dev.openconext.local"
   webauthn:
     stdin_open: true
-    image: ghcr.io/openconext/stepup-webauthn/stepup-webauthn:dev
+    image: ghcr.io/openconext/openconext-basecontainers/php82-apache2-node20-composer2:latest
     volumes:
       - ../../:/var/www/html
       - ${PWD}/webauthn:/config

--- a/ci/docker/init.sh
+++ b/ci/docker/init.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+echo "pulling the images"
+docker compose pull
+echo "starting the images"
+docker compose up -d
+echo "intialising the environment"
+docker compose exec -T webauthn bash -c '
+  cp /var/www/html/config/openconext/parameters.yaml.dist /var/www/html/config/openconext/parameters.yaml && \
+  composer install --prefer-dist -n -o --no-scripts && \
+  ./bin/console assets:install --verbose && \
+  ./bin/console cache:clear && \
+  chown -R www-data:www-data /var/www/html/var/ && \
+  ./bin/console doctrine:migrations:migrate --no-interaction
+'

--- a/ci/docker/readme.md
+++ b/ci/docker/readme.md
@@ -1,0 +1,1 @@
+## Don't use this docker setup in production this is solely for testing purposes!

--- a/ci/qa/doctrine-schema-validate
+++ b/ci/qa/doctrine-schema-validate
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cd $(dirname $0)/../../
+
+printf "Doctrine schema validate\n"
+./bin/console doctrine:schema:validate

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,8 @@
       "@phpcpd",
       "@phpmd",
       "@phpstan",
-      "@unit-tests"
+      "@unit-tests",
+      "@doctrine-schema-validate"
     ],
     "composer-validate": "./ci/qa/validate",
     "docheader": "./ci/qa/docheader",
@@ -101,6 +102,7 @@
     "phpstan": "./ci/qa/phpstan",
     "phpstan-baseline": "./ci/qa/phpstan-update-baseline",
     "unit-tests": "ci/qa/phpunit",
+    "doctrine-schema-validate": "ci/qa/doctrine-schema-validate",
     "frontend-install": [
       "yarn install"
     ],

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -2,7 +2,7 @@ doctrine:
     dbal:
         # configure these for your database server
         driver: 'pdo_mysql'
-        server_version: '5.6'
+        server_version: '10.6.19-MariaDB'
         charset: utf8mb4
         default_table_options:
             charset: utf8mb4

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,6 +1,5 @@
 parameters:
     locale: nl_NL
-    database_url: sqlite:///%kernel.project_dir%/var/webauthn.db
 
 services:
     # default configuration for services in *this* file
@@ -14,6 +13,9 @@ services:
             $supportEmail: '%support_email%'
             $locales: '%locales%'
             $userDisplayName: '%user_display_name%'
+            $jwtMdsBlobFileName: '%fido2_jwt_mds_blob_file_name%'
+            $jwtMdsRootCertFileName: '%fido2_jwt_mds_root_certificate_file_name%'
+            $mdsCacheDir: '%fido2_mds_cache_dir%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Entity/PublicKeyCredentialSource.php
+++ b/src/Entity/PublicKeyCredentialSource.php
@@ -38,12 +38,14 @@ class PublicKeyCredentialSource extends BasePublicKeyCredentialSource
      #[ORM\Id]
      #[ORM\GeneratedValue]
      #[ORM\Column(type:"integer")]
-    private string $id;
+    private int $id;
 
     /**
-     * Override the $uvInitialized field which we do not use, but needs
+     * Override the $backupEligible, $backupStatus and $uvInitialized fields which we do not use, but needs
      * to be initialized. Needed to prevent read before written errors.
      */
+    public ?bool $backupEligible = null;
+    public ?bool $backupStatus = null;
     public ?bool $uvInitialized = false;
 
     public function __construct(

--- a/src/Migrations/Version20250106150814.php
+++ b/src/Migrations/Version20250106150814.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @SuppressWarnings(PHPMD)
+ */
+final class Version20250106150814 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE public_key_credential_sources ADD backup_eligible TINYINT(1) DEFAULT NULL, ADD backup_status TINYINT(1) DEFAULT NULL, ADD uv_initialized TINYINT(1) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE public_key_credential_sources DROP backup_eligible, DROP backup_status, DROP uv_initialized');
+    }
+}

--- a/tests/Integration/Repository/PublicKeyCredentialSourceRepositoryTest.php
+++ b/tests/Integration/Repository/PublicKeyCredentialSourceRepositoryTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright 2024 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Test\Integration\Repository;
+
+use Doctrine\ORM\EntityManager;
+use Surfnet\Webauthn\Entity\PublicKeyCredentialSource;
+use Surfnet\Webauthn\Entity\User;
+use Surfnet\Webauthn\Repository\PublicKeyCredentialSourceRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV4;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+class PublicKeyCredentialSourceRepositoryTest extends KernelTestCase
+{
+    private ?EntityManager $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+    }
+
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->entityManager->close();
+        $this->entityManager = null;
+    }
+
+    public function testRepo()
+    {
+        /** @var PublicKeyCredentialSourceRepository $repo */
+        $repo = $this->entityManager->getRepository(PublicKeyCredentialSource::class);
+
+        $item = new PublicKeyCredentialSource(
+            'id',
+            'type',
+            ['transports'],
+            'attestationType',
+            new EmptyTrustPath(),
+            new Uuid('580c810d-d82f-43ce-9796-6fd000be454a'),
+            'credentialPublicKey',
+            'userHandle',
+            1,
+            'fmt'
+        );
+
+        $repo->saveCredentialSource($item);
+
+        $result = $repo->allForUser(new User('userHandle', 'foo', 'bar'));
+
+        $this->assertNotEmpty($result);
+    }
+
+}


### PR DESCRIPTION
This change:
* Adds support for integration/smoke tests
* Adds an integration test that saves something to the database
* Add doctrine schema validate to the pipeline
* Adds a migration that makes the PublicKeyCredentialSource compatible with the upstream webauthn-framework
* Configure the correct db engine version in doctrine to prevent invalid doctrine mapping