### PR TITLE
Change the error message on fido failures

### DIFF
--- a/templates/default/registration.html.twig
+++ b/templates/default/registration.html.twig
@@ -70,7 +70,7 @@
                     serverData.errorMessage ||
                     'Registration failed';
 
-                setText('title', '{{ "status.webauthn_not_supported"|trans }}');
+                setText('title', '{{ "status.webauthn_not_supported_or_failed"|trans }}');
                 setText('errorMessage', msg);
                 setText('timestamp', new Date().toISOString());
 

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -22,6 +22,7 @@ status.general_error: Oops! something wrong happend, please try again.
 status.webauthn_not_supported: FIDO2 is not supported by your browser.
 status.no_active_request: No active request, return to your service provider.
 status.authenticator_not_supported: This token is not supported, try with a different one.
+status.webauthn_not_supported_or_failed: This token or browser is not supported.
 
 # General
 

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -23,7 +23,7 @@ status.general_error: Oeps! Er is iets fout gegaan, probeer het opnieuw.
 status.webauthn_not_supported: FIDO2 wordt niet ondersteund door jouw browser.
 status.no_active_request: Geen actieve aanvraag, keer terug naar jouw service provider.
 status.authenticator_not_supported: Dit token wordt niet ondersteund, probeer een andere.
-
+status.webauthn_not_supported_or_failed: Dit token of deze browser wordt niet ondersteund.
 # General
 
 ## Buttons


### PR DESCRIPTION
Op dit moment wordt in de webauthn lib geen goede  response gezet als er geen 2xx response terug komt:, dus die is er lastig uit te halen.
https://github.com/web-auth/ux/blob/5.2.x/assets/dist/controller.js#L161
Ik zag eerder wel dat er ook een issue is om dit nog uit te breiden:
https://github.com/web-auth/webauthn-framework/issues/623

Voor nu pas ik de foutmelding aan, en kunnen we dit in als de upstream aanpassingen zijn uitgevoerd hier aanpassingen doen.