### PR TITLE
Override CeremonyStepManagerFactory to enforce authenticator quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ yarn-error.log
 ###> phpunit/phpunit ###
 /phpunit.xml
 .phpunit.result.cache
+ci/qa/.phpunit.cache/
 ###< phpunit/phpunit ###
 
 ###> squizlabs/php_codesniffer ###

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Override CeremonyStepManagerFactory with explicit, controlled ceremony step lists for both registration and authentication
+- Enforce attestation quality during registration: reject TYPE_NONE attestation, require hardware key protection, require FIDO certification, and reject backup-eligible (multi-device/passkey) credentials
+
 ## 2.1.0
 - Upgrade to Symfony 7.4 LTS
 - Remove EOL sensiolabs/security-checker configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## Unreleased
 - Override CeremonyStepManagerFactory with explicit, controlled ceremony step lists for both registration and authentication
 - Enforce attestation quality during registration: reject TYPE_NONE attestation, require hardware key protection, require FIDO certification, and reject backup-eligible (multi-device/passkey) credentials
+- Restrict registration to cross-platform (hardware-bound) authenticators only
+- Make authenticator_attachment, user_verification, and attestation_conveyance configurable via parameters.yaml
+
+### Upgrade instructions
+The following parameters are required and must be added to `parameters.yaml`:
+```yaml
+webauthn_authenticator_attachment: 'cross-platform'
+webauthn_registration_user_verification: 'preferred'
+webauthn_attestation_conveyance: 'direct'
+```
+See `config/openconext/parameters.yaml.dist` for reference values and `\Webauthn\AuthenticatorSelectionCriteria` for available options.
 
 ## 2.1.0
 - Upgrade to Symfony 7.4 LTS

--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: ../../src/Controller/ExceptionController.php
 
 		-
-			message: '#^Property Surfnet\\Webauthn\\Entity\\PublicKeyCredentialSource\:\:\$fmt is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: ../../src/Entity/PublicKeyCredentialSource.php
-
-		-
 			message: '#^Class Surfnet\\Webauthn\\Entity\\User has an uninitialized readonly property \$displayName\. Assign it in the constructor\.$#'
 			identifier: property.uninitializedReadonly
 			count: 1

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -31,3 +31,6 @@ services:
 
     Webauthn\Bundle\Repository\CanRegisterUserEntity:
         alias: Surfnet\Webauthn\Repository\UserRepository
+
+    Webauthn\CeremonyStep\CeremonyStepManagerFactory:
+        class: Surfnet\Webauthn\CeremonyStep\SurfnetCeremonyStepManagerFactory

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -42,3 +42,9 @@ services:
 
     Surfnet\GsspBundle\Service\ValueStore\SessionValueStore:
         alias: surfnet_gssp.value_store.service
+
+    # MetadataStatementService parses the MDS blob eagerly in its constructor.
+    # blob.jwt is not committed, so we make it lazy in tests — the proxy is injected
+    # but the blob is never parsed unless a method is actually called.
+    Surfnet\Webauthn\Service\MetadataStatementService:
+        lazy: true

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -72,3 +72,22 @@ Install (without build archive)
 APP_ENV=prod APP_DEBUG=0 php bin/console cache:clear
 ```
 
+### 6. Keep the FIDO Metadata Service (MDS) blob up to date
+
+The application validates authenticators against the FIDO Alliance Metadata Service.
+The blob must be present at `config/openconext/mds/blob.jwt` and refreshed periodically
+(FIDO publishes updates roughly every two weeks; the blob contains a `nextUpdate` field
+that declares its expiry date).
+
+If the blob is outdated, newly registered authenticators that are not already cached will
+be rejected with a hard error during registration. Existing credentials are not affected.
+
+**Update procedure:**
+1. Download the latest blob from https://fidoalliance.org/metadata/ (see "Obtaining blob").
+2. Replace `config/openconext/mds/blob.jwt` with the new file.
+3. Clear the MDS cache: `bin/console cache:pool:clear cache.app` (or delete `var/mds/`).
+4. The root certificate `config/openconext/mds/root.crt` rarely changes; verify it only
+   when the FIDO Alliance announces a root rotation.
+
+Recommendation: schedule blob updates as part of your regular maintenance window (monthly is sufficient).
+

--- a/src/CeremonyStep/CheckAttestationIsNotNone.php
+++ b/src/CeremonyStep/CheckAttestationIsNotNone.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Surfnet\Webauthn\CeremonyStep;
 
+use Psr\Log\LoggerInterface;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -31,6 +32,10 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckAttestationIsNotNone implements CeremonyStep
 {
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
     public function process(
         PublicKeyCredentialSource $publicKeyCredentialSource,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
@@ -42,12 +47,20 @@ final class CheckAttestationIsNotNone implements CeremonyStep
             return;
         }
 
+        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
         $attestationType = $authenticatorResponse->attestationObject->attStmt->type;
+
+        $this->logger->info('Checking attestation type is not none', [
+            'registrationId' => $registrationId,
+            'attestationType' => $attestationType,
+        ]);
 
         if ($attestationType === AttestationStatement::TYPE_NONE) {
             throw AuthenticatorResponseVerificationException::create(
                 'Attestation is required. TYPE_NONE responses are not accepted.'
             );
         }
+
+        $this->logger->info('Attestation type accepted', ['registrationId' => $registrationId]);
     }
 }

--- a/src/CeremonyStep/CheckAttestationIsNotNone.php
+++ b/src/CeremonyStep/CheckAttestationIsNotNone.php
@@ -32,6 +32,7 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckAttestationIsNotNone implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -47,7 +48,7 @@ final class CheckAttestationIsNotNone implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $attestationType = $authenticatorResponse->attestationObject->attStmt->type;
 
         $this->logger->info('Checking attestation type is not none', [

--- a/src/CeremonyStep/CheckAttestationIsNotNone.php
+++ b/src/CeremonyStep/CheckAttestationIsNotNone.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\CeremonyStep;
+
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\CeremonyStep\CeremonyStep;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
+
+final class CheckAttestationIsNotNone implements CeremonyStep
+{
+    public function process(
+        PublicKeyCredentialSource $publicKeyCredentialSource,
+        AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
+        PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
+        ?string $userHandle,
+        string $host
+    ): void {
+        if (!$authenticatorResponse instanceof AuthenticatorAttestationResponse) {
+            return;
+        }
+
+        $attestationType = $authenticatorResponse->attestationObject->attStmt->type;
+
+        if ($attestationType === AttestationStatement::TYPE_NONE) {
+            throw AuthenticatorResponseVerificationException::create(
+                'Attestation is required. TYPE_NONE responses are not accepted.'
+            );
+        }
+    }
+}

--- a/src/CeremonyStep/CheckFidoCertified.php
+++ b/src/CeremonyStep/CheckFidoCertified.php
@@ -92,7 +92,9 @@ final class CheckFidoCertified implements CeremonyStep
      */
     private function mostRecentReport(array $reports): StatusReport
     {
-        assert($reports !== []);
+        if ($reports === []) {
+            throw new \LogicException('mostRecentReport() called with empty reports array.');
+        }
         // Tie-break: equal dates keep the later array index (stable for FIDO MDS, one report per event).
         return array_reduce(
             $reports,

--- a/src/CeremonyStep/CheckFidoCertified.php
+++ b/src/CeremonyStep/CheckFidoCertified.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\CeremonyStep;
+
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\CeremonyStep\CeremonyStep;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\MetadataService\Statement\AuthenticatorStatus;
+use Webauthn\MetadataService\Statement\StatusReport;
+use Webauthn\MetadataService\StatusReportRepository;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
+
+final class CheckFidoCertified implements CeremonyStep
+{
+    private const FIDO_CERTIFIED_STATUSES = [
+        AuthenticatorStatus::FIDO_CERTIFIED,
+        AuthenticatorStatus::FIDO_CERTIFIED_L1,
+        AuthenticatorStatus::FIDO_CERTIFIED_L1plus,
+        AuthenticatorStatus::FIDO_CERTIFIED_L2,
+        AuthenticatorStatus::FIDO_CERTIFIED_L2plus,
+        AuthenticatorStatus::FIDO_CERTIFIED_L3,
+        AuthenticatorStatus::FIDO_CERTIFIED_L3plus,
+        AuthenticatorStatus::FIDO_CERTIFIED_L4,
+        AuthenticatorStatus::FIDO_CERTIFIED_L5,
+    ];
+
+    public function __construct(
+        private readonly StatusReportRepository $statusReportRepository,
+    ) {
+    }
+
+    public function process(
+        PublicKeyCredentialSource $publicKeyCredentialSource,
+        AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
+        PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
+        ?string $userHandle,
+        string $host
+    ): void {
+        if (!$authenticatorResponse instanceof AuthenticatorAttestationResponse) {
+            return;
+        }
+
+        $attestedCredentialData = $authenticatorResponse->attestationObject->authData->attestedCredentialData;
+        if ($attestedCredentialData === null) {
+            return;
+        }
+
+        $aaguid = $attestedCredentialData->aaguid->__toString();
+        $reports = $this->statusReportRepository->findStatusReportsByAAGUID($aaguid);
+
+        if ($reports === []) {
+            throw AuthenticatorResponseVerificationException::create(
+                sprintf('No status reports found for authenticator with AAGUID "%s".', $aaguid)
+            );
+        }
+
+        $mostRecent = $this->mostRecentReport($reports);
+
+        if (!in_array($mostRecent->status, self::FIDO_CERTIFIED_STATUSES, true)) {
+            throw AuthenticatorResponseVerificationException::create(
+                sprintf(
+                    'Authenticator is not FIDO certified. Most recent status: "%s".',
+                    $mostRecent->status
+                )
+            );
+        }
+    }
+
+    /**
+     * @param StatusReport[] $reports
+     */
+    private function mostRecentReport(array $reports): StatusReport
+    {
+        assert($reports !== []);
+        // Tie-break: equal dates keep the later array index (stable for FIDO MDS, one report per event).
+        return array_reduce(
+            $reports,
+            fn(StatusReport $carry, StatusReport $report): StatusReport =>
+                ($report->effectiveDate ?? '') >= ($carry->effectiveDate ?? '') ? $report : $carry,
+            $reports[0]
+        );
+    }
+}

--- a/src/CeremonyStep/CheckFidoCertified.php
+++ b/src/CeremonyStep/CheckFidoCertified.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace Surfnet\Webauthn\CeremonyStep;
 
 use LogicException;
+use Psr\Log\LoggerInterface;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
@@ -48,6 +49,7 @@ final class CheckFidoCertified implements CeremonyStep
 
     public function __construct(
         private readonly StatusReportRepository $statusReportRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -67,8 +69,15 @@ final class CheckFidoCertified implements CeremonyStep
             return;
         }
 
+        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $reports = $this->statusReportRepository->findStatusReportsByAAGUID($aaguid);
+
+        $this->logger->info('Checking FIDO certification status', [
+            'registrationId' => $registrationId,
+            'aaguid' => $aaguid,
+            'statusReportCount' => count($reports),
+        ]);
 
         if ($reports === []) {
             throw AuthenticatorResponseVerificationException::create(
@@ -78,6 +87,13 @@ final class CheckFidoCertified implements CeremonyStep
 
         $mostRecent = $this->mostRecentReport($reports);
 
+        $this->logger->info('Most recent FIDO status report', [
+            'registrationId' => $registrationId,
+            'aaguid' => $aaguid,
+            'status' => $mostRecent->status,
+            'effectiveDate' => $mostRecent->effectiveDate,
+        ]);
+
         if (!in_array($mostRecent->status, self::FIDO_CERTIFIED_STATUSES, true)) {
             throw AuthenticatorResponseVerificationException::create(
                 sprintf(
@@ -86,6 +102,8 @@ final class CheckFidoCertified implements CeremonyStep
                 )
             );
         }
+
+        $this->logger->info('FIDO certification check passed', ['registrationId' => $registrationId]);
     }
 
     /**

--- a/src/CeremonyStep/CheckFidoCertified.php
+++ b/src/CeremonyStep/CheckFidoCertified.php
@@ -35,6 +35,8 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckFidoCertified implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     private const FIDO_CERTIFIED_STATUSES = [
         AuthenticatorStatus::FIDO_CERTIFIED,
         AuthenticatorStatus::FIDO_CERTIFIED_L1,
@@ -69,7 +71,7 @@ final class CheckFidoCertified implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $reports = $this->statusReportRepository->findStatusReportsByAAGUID($aaguid);
 

--- a/src/CeremonyStep/CheckFidoCertified.php
+++ b/src/CeremonyStep/CheckFidoCertified.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Surfnet\Webauthn\CeremonyStep;
 
+use LogicException;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
@@ -93,7 +94,7 @@ final class CheckFidoCertified implements CeremonyStep
     private function mostRecentReport(array $reports): StatusReport
     {
         if ($reports === []) {
-            throw new \LogicException('mostRecentReport() called with empty reports array.');
+            throw new LogicException('mostRecentReport() called with empty reports array.');
         }
         // Tie-break: equal dates keep the later array index (stable for FIDO MDS, one report per event).
         return array_reduce(

--- a/src/CeremonyStep/CheckHardwareKeyProtection.php
+++ b/src/CeremonyStep/CheckHardwareKeyProtection.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\CeremonyStep;
+
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\CeremonyStep\CeremonyStep;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\MetadataService\MetadataStatementRepository;
+use Webauthn\MetadataService\Statement\MetadataStatement;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
+
+final class CheckHardwareKeyProtection implements CeremonyStep
+{
+    private const ALLOWED_KEY_PROTECTION = [
+        MetadataStatement::KEY_PROTECTION_HARDWARE,
+        MetadataStatement::KEY_PROTECTION_SECURE_ELEMENT,
+    ];
+
+    public function __construct(
+        private readonly MetadataStatementRepository $metadataStatementRepository,
+    ) {
+    }
+
+    public function process(
+        PublicKeyCredentialSource $publicKeyCredentialSource,
+        AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
+        PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
+        ?string $userHandle,
+        string $host
+    ): void {
+        if (!$authenticatorResponse instanceof AuthenticatorAttestationResponse) {
+            return;
+        }
+
+        $attestedCredentialData = $authenticatorResponse->attestationObject->authData->attestedCredentialData;
+        if ($attestedCredentialData === null) {
+            return;
+        }
+
+        $aaguid = $attestedCredentialData->aaguid->__toString();
+        $metadataStatement = $this->metadataStatementRepository->findOneByAAGUID($aaguid);
+
+        // No MDS entry means we cannot verify key protection for this AAGUID.
+        // TYPE_NONE attestation is already rejected by CheckAttestationIsNotNone,
+        // so this only affects authenticators that attest but are absent from the FIDO MDS.
+        if ($metadataStatement === null) {
+            return;
+        }
+
+        if (count(array_intersect($metadataStatement->keyProtection, self::ALLOWED_KEY_PROTECTION)) === 0) {
+            throw AuthenticatorResponseVerificationException::create(
+                sprintf(
+                    'Authenticator key is not hardware-bound. keyProtection: [%s]',
+                    implode(', ', $metadataStatement->keyProtection)
+                )
+            );
+        }
+    }
+}

--- a/src/CeremonyStep/CheckHardwareKeyProtection.php
+++ b/src/CeremonyStep/CheckHardwareKeyProtection.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Surfnet\Webauthn\CeremonyStep;
 
+use Psr\Log\LoggerInterface;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
@@ -39,6 +40,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
 
     public function __construct(
         private readonly MetadataStatementRepository $metadataStatementRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -58,6 +60,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
             return;
         }
 
+        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $metadataStatement = $this->metadataStatementRepository->findOneByAAGUID($aaguid);
 
@@ -65,8 +68,19 @@ final class CheckHardwareKeyProtection implements CeremonyStep
         // TYPE_NONE attestation is already rejected by CheckAttestationIsNotNone,
         // so this only affects authenticators that attest but are absent from the FIDO MDS.
         if ($metadataStatement === null) {
+            $this->logger->info('No MDS metadata statement found for AAGUID, skipping key protection check', [
+                'registrationId' => $registrationId,
+                'aaguid' => $aaguid,
+            ]);
             return;
         }
+
+        $this->logger->info('MDS metadata statement found for authenticator', [
+            'registrationId' => $registrationId,
+            'aaguid' => $aaguid,
+            'description' => isset($metadataStatement->description) ? $metadataStatement->description : null,
+            'keyProtection' => $metadataStatement->keyProtection,
+        ]);
 
         if (count(array_intersect($metadataStatement->keyProtection, self::ALLOWED_KEY_PROTECTION)) === 0) {
             throw AuthenticatorResponseVerificationException::create(
@@ -76,5 +90,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
                 )
             );
         }
+
+        $this->logger->info('Key protection check passed', ['registrationId' => $registrationId]);
     }
 }

--- a/src/CeremonyStep/CheckHardwareKeyProtection.php
+++ b/src/CeremonyStep/CheckHardwareKeyProtection.php
@@ -33,6 +33,8 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckHardwareKeyProtection implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     private const ALLOWED_KEY_PROTECTION = [
         MetadataStatement::KEY_PROTECTION_HARDWARE,
         MetadataStatement::KEY_PROTECTION_SECURE_ELEMENT,
@@ -60,7 +62,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $metadataStatement = $this->metadataStatementRepository->findOneByAAGUID($aaguid);
 

--- a/src/CeremonyStep/CheckNoBackupEligibility.php
+++ b/src/CeremonyStep/CheckNoBackupEligibility.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\CeremonyStep;
+
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\CeremonyStep\CeremonyStep;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
+
+/**
+ * Rejects credentials that are backup-eligible (i.e. can be synced across devices / passkeys).
+ * This is the runtime proxy for the MDS multiDeviceCredentialSupport field, which is not
+ * exposed in webauthn-lib v5.
+ */
+final class CheckNoBackupEligibility implements CeremonyStep
+{
+    public function process(
+        PublicKeyCredentialSource $publicKeyCredentialSource,
+        AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
+        PublicKeyCredentialRequestOptions|PublicKeyCredentialCreationOptions $publicKeyCredentialOptions,
+        ?string $userHandle,
+        string $host
+    ): void {
+        if (!$authenticatorResponse instanceof AuthenticatorAttestationResponse) {
+            return;
+        }
+
+        $authData = $authenticatorResponse->attestationObject->authData;
+
+        if ($authData->isBackupEligible()) {
+            throw AuthenticatorResponseVerificationException::create(
+                'Multi-device credentials are not accepted. The authenticator must not be backup-eligible.'
+            );
+        }
+    }
+}

--- a/src/CeremonyStep/CheckNoBackupEligibility.php
+++ b/src/CeremonyStep/CheckNoBackupEligibility.php
@@ -36,6 +36,8 @@ use Webauthn\PublicKeyCredentialSource;
  */
 final class CheckNoBackupEligibility implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -51,7 +53,7 @@ final class CheckNoBackupEligibility implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $authData = $authenticatorResponse->attestationObject->authData;
 
         $this->logger->info('Checking backup eligibility', [

--- a/src/CeremonyStep/LogAuthenticationData.php
+++ b/src/CeremonyStep/LogAuthenticationData.php
@@ -21,21 +21,23 @@ declare(strict_types=1);
 namespace Surfnet\Webauthn\CeremonyStep;
 
 use Psr\Log\LoggerInterface;
+use Surfnet\Webauthn\Entity\PublicKeyCredentialSource as SurfnetPublicKeyCredentialSource;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
-use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 
 /**
- * Rejects credentials that are backup-eligible (i.e. can be synced across devices / passkeys).
- * This is the runtime proxy for the MDS multiDeviceCredentialSupport field, which is not
- * exposed in webauthn-lib v5.
+ * First step in the request ceremony. Logs the AAGUID of the authenticating credential.
+ * Warns when the credential has a null AAGUID (CTAP1/U2F legacy token).
+ * Never throws — purely observational.
  */
-final class CheckNoBackupEligibility implements CeremonyStep
+final class LogAuthenticationData implements CeremonyStep
 {
+    private const NULL_AAGUID = '00000000-0000-0000-0000-000000000000';
+
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -47,24 +49,28 @@ final class CheckNoBackupEligibility implements CeremonyStep
         ?string $userHandle,
         string $host
     ): void {
-        if (!$authenticatorResponse instanceof AuthenticatorAttestationResponse) {
+        if (!$authenticatorResponse instanceof AuthenticatorAssertionResponse) {
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
-        $authData = $authenticatorResponse->attestationObject->authData;
+        $aaguid = $publicKeyCredentialSource->aaguid->__toString();
+        $fmt = $publicKeyCredentialSource instanceof SurfnetPublicKeyCredentialSource
+            ? $publicKeyCredentialSource->getFmt()
+            : null;
 
-        $this->logger->info('Checking backup eligibility', [
-            'registrationId' => $registrationId,
-            'isBackupEligible' => $authData->isBackupEligible(),
-        ]);
-
-        if ($authData->isBackupEligible()) {
-            throw AuthenticatorResponseVerificationException::create(
-                'Multi-device credentials are not accepted. The authenticator must not be backup-eligible.'
-            );
+        if ($aaguid === self::NULL_AAGUID) {
+            $this->logger->warning('Authentication with legacy token: null AAGUID indicates CTAP1/U2F credential registered before FIDO MDS enforcement', [
+                'aaguid' => $aaguid,
+                'fmt' => $fmt,
+                'userHandle' => $userHandle,
+            ]);
+            return;
         }
 
-        $this->logger->info('Backup eligibility check passed', ['registrationId' => $registrationId]);
+        $this->logger->info('Authentication ceremony started', [
+            'aaguid' => $aaguid,
+            'fmt' => $fmt,
+            'userHandle' => $userHandle,
+        ]);
     }
 }

--- a/src/CeremonyStep/LogRegistrationData.php
+++ b/src/CeremonyStep/LogRegistrationData.php
@@ -34,6 +34,8 @@ use Webauthn\PublicKeyCredentialSource;
  */
 final class LogRegistrationData implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -49,7 +51,7 @@ final class LogRegistrationData implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
 
         $attestedCredentialData = $authenticatorResponse->attestationObject->authData->attestedCredentialData;
         $aaguid = $attestedCredentialData?->aaguid->__toString() ?? '00000000-0000-0000-0000-000000000000';

--- a/src/CeremonyStep/LogRegistrationData.php
+++ b/src/CeremonyStep/LogRegistrationData.php
@@ -24,17 +24,15 @@ use Psr\Log\LoggerInterface;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
-use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 
 /**
- * Rejects credentials that are backup-eligible (i.e. can be synced across devices / passkeys).
- * This is the runtime proxy for the MDS multiDeviceCredentialSupport field, which is not
- * exposed in webauthn-lib v5.
+ * First step in the creation ceremony. Logs the raw attestation data for audit/debugging purposes.
+ * Never throws — purely observational.
  */
-final class CheckNoBackupEligibility implements CeremonyStep
+final class LogRegistrationData implements CeremonyStep
 {
     public function __construct(private readonly LoggerInterface $logger)
     {
@@ -52,19 +50,25 @@ final class CheckNoBackupEligibility implements CeremonyStep
         }
 
         $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
-        $authData = $authenticatorResponse->attestationObject->authData;
 
-        $this->logger->info('Checking backup eligibility', [
+        $attestedCredentialData = $authenticatorResponse->attestationObject->authData->attestedCredentialData;
+        $aaguid = $attestedCredentialData?->aaguid->__toString() ?? '00000000-0000-0000-0000-000000000000';
+
+        $this->logger->info('Registration ceremony started', [
             'registrationId' => $registrationId,
-            'isBackupEligible' => $authData->isBackupEligible(),
+            'aaguid' => $aaguid,
+            'attestationFormat' => $authenticatorResponse->attestationObject->attStmt->fmt,
+            'clientDataType' => $authenticatorResponse->clientDataJSON->type,
+            'origin' => $authenticatorResponse->clientDataJSON->origin,
         ]);
 
-        if ($authData->isBackupEligible()) {
-            throw AuthenticatorResponseVerificationException::create(
-                'Multi-device credentials are not accepted. The authenticator must not be backup-eligible.'
-            );
-        }
-
-        $this->logger->info('Backup eligibility check passed', ['registrationId' => $registrationId]);
+        $this->logger->info('Registration ceremony raw attestation data', [
+            'registrationId' => $registrationId,
+            'clientDataJSON' => $authenticatorResponse->clientDataJSON->rawData,
+            'attestationObject' => sodium_bin2base64(
+                $authenticatorResponse->attestationObject->rawAttestationObject,
+                SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+            ),
+        ]);
     }
 }

--- a/src/CeremonyStep/RegistrationIdFromChallenge.php
+++ b/src/CeremonyStep/RegistrationIdFromChallenge.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\CeremonyStep;
+
+trait RegistrationIdFromChallenge
+{
+    private function registrationId(string $challenge): string
+    {
+        return sodium_bin2base64($challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+    }
+}

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -98,7 +98,6 @@ final class SurfnetCeremonyStepManagerFactory
         $this->counterChecker = $counterChecker;
     }
 
-    //even uitzoeken waar dit gebruikt wordt en of het verwijderd worden
     /**
      * @deprecated since 5.2.0 and will be removed in 6.0.0. Use setAllowedOrigins instead.
      * @todo Remove this method when upgrading webauthn-lib to 6.0.

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace Surfnet\Webauthn\CeremonyStep;
 
-use LogicException;
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Algorithm\Signature\RSA\RS256;
@@ -55,6 +54,10 @@ use Webauthn\MetadataService\MetadataStatementRepository;
 use Webauthn\MetadataService\StatusReportRepository;
 
 /**
+ * Overrides the webauthn-lib CeremonyStepManagerFactory to enforce authenticator quality
+ * requirements (hardware key protection, FIDO certification, no passkeys) beyond what the
+ * upstream factory provides.
+ *
  * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
  */
 final class SurfnetCeremonyStepManagerFactory
@@ -62,12 +65,6 @@ final class SurfnetCeremonyStepManagerFactory
     private CounterChecker $counterChecker;
 
     private Manager $algorithmManager;
-
-    private null|MetadataStatementRepository $metadataStatementRepository = null;
-
-    private null|StatusReportRepository $statusReportRepository = null;
-
-    private null|CertificateChainValidator $certificateChainValidator = null;
 
     private null|TopOriginValidator $topOriginValidator = null;
 
@@ -83,8 +80,11 @@ final class SurfnetCeremonyStepManagerFactory
 
     private ExtensionOutputCheckerHandler $extensionOutputCheckerHandler;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly MetadataStatementRepository $metadataStatementRepository,
+        private readonly StatusReportRepository $statusReportRepository,
+        private readonly CertificateChainValidator $certificateChainValidator,
+    ) {
         $this->counterChecker = new ThrowExceptionIfInvalid();
         $this->algorithmManager = Manager::create()->add(ES256::create(), RS256::create());
         $this->attestationStatementSupportManager = new AttestationStatementSupportManager([
@@ -98,6 +98,7 @@ final class SurfnetCeremonyStepManagerFactory
         $this->counterChecker = $counterChecker;
     }
 
+    //even uitzoeken waar dit gebruikt wordt en of het verwijderd worden
     /**
      * @deprecated since 5.2.0 and will be removed in 6.0.0. Use setAllowedOrigins instead.
      * @todo Remove this method when upgrading webauthn-lib to 6.0.
@@ -133,19 +134,20 @@ final class SurfnetCeremonyStepManagerFactory
         $this->algorithmManager = $algorithmManager;
     }
 
+    /**
+     * Called by the webauthn bundle's CeremonyStepManagerFactoryCompilerPass. The dependencies
+     * are already injected via the constructor; this setter exists only to satisfy the compiler
+     * pass contract and is a no-op.
+     */
     public function enableMetadataStatementSupport(
         MetadataStatementRepository $metadataStatementRepository,
         StatusReportRepository $statusReportRepository,
         CertificateChainValidator $certificateChainValidator
     ): void {
-        $this->metadataStatementRepository = $metadataStatementRepository;
-        $this->statusReportRepository = $statusReportRepository;
-        $this->certificateChainValidator = $certificateChainValidator;
     }
 
     public function enableCertificateChainValidator(CertificateChainValidator $certificateChainValidator): void
     {
-        $this->certificateChainValidator = $certificateChainValidator;
     }
 
     public function enableTopOriginValidator(TopOriginValidator $topOriginValidator): void
@@ -157,22 +159,13 @@ final class SurfnetCeremonyStepManagerFactory
     // and requestCeremony() against these lists and port any new or reordered steps.
     public function creationCeremony(): CeremonyStepManager
     {
-        if ($this->metadataStatementRepository === null || $this->statusReportRepository === null) {
-            throw new LogicException(
-                'MDS must be configured before calling creationCeremony(). ' .
-                'Call enableMetadataStatementSupport() first.'
-            );
-        }
-
         $metadataStatementChecker = new CheckMetadataStatement();
-        if ($this->certificateChainValidator !== null) {
-            $metadataStatementChecker->enableCertificateChainValidator($this->certificateChainValidator);
-            $metadataStatementChecker->enableMetadataStatementSupport(
-                $this->metadataStatementRepository,
-                $this->statusReportRepository,
-                $this->certificateChainValidator,
-            );
-        }
+        $metadataStatementChecker->enableCertificateChainValidator($this->certificateChainValidator);
+        $metadataStatementChecker->enableMetadataStatementSupport(
+            $this->metadataStatementRepository,
+            $this->statusReportRepository,
+            $this->certificateChainValidator,
+        );
 
         $originStep = $this->allowedOrigins === null
             ? new CheckOrigin($this->securedRelyingPartyId ?? [])

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -188,11 +188,11 @@ final class SurfnetCeremonyStepManagerFactory
             new CheckNoBackupEligibility(),
             new CheckAlgorithm(),
             new CheckExtensions($this->extensionOutputCheckerHandler),
+            new CheckAttestationIsNotNone(),
             new CheckAttestationFormatIsKnownAndValid($this->attestationStatementSupportManager),
             new CheckHasAttestedCredentialData(),
             $metadataStatementChecker,
             new CheckCredentialId(),
-            new CheckAttestationIsNotNone(),
             new CheckHardwareKeyProtection($this->metadataStatementRepository),
             new CheckFidoCertified($this->statusReportRepository),
         ]);

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Surfnet\Webauthn\CeremonyStep;
 
+use LogicException;
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Algorithm\Signature\RSA\RS256;
@@ -157,7 +158,7 @@ final class SurfnetCeremonyStepManagerFactory
     public function creationCeremony(): CeremonyStepManager
     {
         if ($this->metadataStatementRepository === null || $this->statusReportRepository === null) {
-            throw new \LogicException(
+            throw new LogicException(
                 'MDS must be configured before calling creationCeremony(). ' .
                 'Call enableMetadataStatementSupport() first.'
             );

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -23,6 +23,7 @@ namespace Surfnet\Webauthn\CeremonyStep;
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Algorithm\Signature\RSA\RS256;
+use Psr\Log\LoggerInterface;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
 use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
@@ -81,6 +82,7 @@ final class SurfnetCeremonyStepManagerFactory
     private ExtensionOutputCheckerHandler $extensionOutputCheckerHandler;
 
     public function __construct(
+        private readonly LoggerInterface $logger,
         private readonly MetadataStatementRepository $metadataStatementRepository,
         private readonly StatusReportRepository $statusReportRepository,
         private readonly CertificateChainValidator $certificateChainValidator,
@@ -171,6 +173,7 @@ final class SurfnetCeremonyStepManagerFactory
             : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains);
 
         return new CeremonyStepManager([
+            new LogRegistrationData($this->logger),
             new CheckClientDataCollectorType(),
             new CheckChallenge(),
             $originStep,
@@ -178,16 +181,16 @@ final class SurfnetCeremonyStepManagerFactory
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
             new CheckUserVerification(),
-            new CheckNoBackupEligibility(),
+            new CheckNoBackupEligibility($this->logger),
             new CheckAlgorithm(),
             new CheckExtensions($this->extensionOutputCheckerHandler),
-            new CheckAttestationIsNotNone(),
+            new CheckAttestationIsNotNone($this->logger),
             new CheckAttestationFormatIsKnownAndValid($this->attestationStatementSupportManager),
             new CheckHasAttestedCredentialData(),
             $metadataStatementChecker,
             new CheckCredentialId(),
-            new CheckHardwareKeyProtection($this->metadataStatementRepository),
-            new CheckFidoCertified($this->statusReportRepository),
+            new CheckHardwareKeyProtection($this->metadataStatementRepository, $this->logger),
+            new CheckFidoCertified($this->statusReportRepository, $this->logger),
         ]);
     }
 
@@ -198,6 +201,7 @@ final class SurfnetCeremonyStepManagerFactory
             : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains);
 
         return new CeremonyStepManager([
+            new LogAuthenticationData($this->logger),
             new CheckAllowedCredentialList(),
             new CheckUserHandle(),
             new CheckClientDataCollectorType(),

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -1,0 +1,225 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\CeremonyStep;
+
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
+use Webauthn\CeremonyStep\CeremonyStepManager;
+use Webauthn\CeremonyStep\CheckAlgorithm;
+use Webauthn\CeremonyStep\CheckAllowedCredentialList;
+use Webauthn\CeremonyStep\CheckAllowedOrigins;
+use Webauthn\CeremonyStep\CheckAttestationFormatIsKnownAndValid;
+use Webauthn\CeremonyStep\CheckBackupBitsAreConsistent;
+use Webauthn\CeremonyStep\CheckChallenge;
+use Webauthn\CeremonyStep\CheckClientDataCollectorType;
+use Webauthn\CeremonyStep\CheckCounter;
+use Webauthn\CeremonyStep\CheckCredentialId;
+use Webauthn\CeremonyStep\CheckExtensions;
+use Webauthn\CeremonyStep\CheckHasAttestedCredentialData;
+use Webauthn\CeremonyStep\CheckMetadataStatement;
+use Webauthn\CeremonyStep\CheckOrigin;
+use Webauthn\CeremonyStep\CheckRelyingPartyIdIdHash;
+use Webauthn\CeremonyStep\CheckSignature;
+use Webauthn\CeremonyStep\CheckTopOrigin;
+use Webauthn\CeremonyStep\CheckUserHandle;
+use Webauthn\CeremonyStep\CheckUserVerification;
+use Webauthn\CeremonyStep\CheckUserWasPresent;
+use Webauthn\CeremonyStep\TopOriginValidator;
+use Webauthn\Counter\CounterChecker;
+use Webauthn\Counter\ThrowExceptionIfInvalid;
+use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
+use Webauthn\MetadataService\MetadataStatementRepository;
+use Webauthn\MetadataService\StatusReportRepository;
+
+/**
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
+ */
+final class SurfnetCeremonyStepManagerFactory
+{
+    private CounterChecker $counterChecker;
+
+    private Manager $algorithmManager;
+
+    private null|MetadataStatementRepository $metadataStatementRepository = null;
+
+    private null|StatusReportRepository $statusReportRepository = null;
+
+    private null|CertificateChainValidator $certificateChainValidator = null;
+
+    private null|TopOriginValidator $topOriginValidator = null;
+
+    /** @var string[]|null */
+    private null|array $securedRelyingPartyId = null;
+
+    /** @var string[]|null */
+    private null|array $allowedOrigins = null;
+
+    private bool $allowSubdomains = false;
+
+    private AttestationStatementSupportManager $attestationStatementSupportManager;
+
+    private ExtensionOutputCheckerHandler $extensionOutputCheckerHandler;
+
+    public function __construct()
+    {
+        $this->counterChecker = new ThrowExceptionIfInvalid();
+        $this->algorithmManager = Manager::create()->add(ES256::create(), RS256::create());
+        $this->attestationStatementSupportManager = new AttestationStatementSupportManager([
+            new NoneAttestationStatementSupport(),
+        ]);
+        $this->extensionOutputCheckerHandler = new ExtensionOutputCheckerHandler();
+    }
+
+    public function setCounterChecker(CounterChecker $counterChecker): void
+    {
+        $this->counterChecker = $counterChecker;
+    }
+
+    /**
+     * @deprecated since 5.2.0 and will be removed in 6.0.0. Use setAllowedOrigins instead.
+     * @todo Remove this method when upgrading webauthn-lib to 6.0.
+     * @param string[] $securedRelyingPartyId
+     */
+    public function setSecuredRelyingPartyId(array $securedRelyingPartyId): void
+    {
+        $this->securedRelyingPartyId = $securedRelyingPartyId;
+    }
+
+    /**
+     * @param string[] $allowedOrigins
+     */
+    public function setAllowedOrigins(array $allowedOrigins, bool $allowSubdomains = false): void
+    {
+        $this->allowedOrigins = $allowedOrigins;
+        $this->allowSubdomains = $allowSubdomains;
+    }
+
+    public function setExtensionOutputCheckerHandler(ExtensionOutputCheckerHandler $extensionOutputCheckerHandler): void
+    {
+        $this->extensionOutputCheckerHandler = $extensionOutputCheckerHandler;
+    }
+
+    public function setAttestationStatementSupportManager(
+        AttestationStatementSupportManager $attestationStatementSupportManager
+    ): void {
+        $this->attestationStatementSupportManager = $attestationStatementSupportManager;
+    }
+
+    public function setAlgorithmManager(Manager $algorithmManager): void
+    {
+        $this->algorithmManager = $algorithmManager;
+    }
+
+    public function enableMetadataStatementSupport(
+        MetadataStatementRepository $metadataStatementRepository,
+        StatusReportRepository $statusReportRepository,
+        CertificateChainValidator $certificateChainValidator
+    ): void {
+        $this->metadataStatementRepository = $metadataStatementRepository;
+        $this->statusReportRepository = $statusReportRepository;
+        $this->certificateChainValidator = $certificateChainValidator;
+    }
+
+    public function enableCertificateChainValidator(CertificateChainValidator $certificateChainValidator): void
+    {
+        $this->certificateChainValidator = $certificateChainValidator;
+    }
+
+    public function enableTopOriginValidator(TopOriginValidator $topOriginValidator): void
+    {
+        $this->topOriginValidator = $topOriginValidator;
+    }
+
+    // Upgrade note: when bumping webauthn-lib, diff vendor CeremonyStepManagerFactory::creationCeremony()
+    // and requestCeremony() against these lists and port any new or reordered steps.
+    public function creationCeremony(): CeremonyStepManager
+    {
+        $metadataStatementChecker = new CheckMetadataStatement();
+        if ($this->certificateChainValidator !== null) {
+            $metadataStatementChecker->enableCertificateChainValidator($this->certificateChainValidator);
+        }
+        if ($this->metadataStatementRepository !== null && $this->statusReportRepository !== null && $this->certificateChainValidator !== null) {
+            $metadataStatementChecker->enableMetadataStatementSupport(
+                $this->metadataStatementRepository,
+                $this->statusReportRepository,
+                $this->certificateChainValidator,
+            );
+        }
+
+        $originStep = $this->allowedOrigins === null
+            ? new CheckOrigin($this->securedRelyingPartyId ?? [])
+            : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains);
+
+        $steps = [
+            new CheckClientDataCollectorType(),
+            new CheckChallenge(),
+            $originStep,
+            new CheckTopOrigin($this->topOriginValidator),
+            new CheckRelyingPartyIdIdHash(),
+            new CheckUserWasPresent(),
+            new CheckUserVerification(),
+            new CheckNoBackupEligibility(),
+            new CheckAlgorithm(),
+            new CheckExtensions($this->extensionOutputCheckerHandler),
+            new CheckAttestationFormatIsKnownAndValid($this->attestationStatementSupportManager),
+            new CheckHasAttestedCredentialData(),
+            $metadataStatementChecker,
+            new CheckCredentialId(),
+            new CheckAttestationIsNotNone(),
+        ];
+
+        if ($this->metadataStatementRepository !== null) {
+            $steps[] = new CheckHardwareKeyProtection($this->metadataStatementRepository);
+        }
+        if ($this->statusReportRepository !== null) {
+            $steps[] = new CheckFidoCertified($this->statusReportRepository);
+        }
+
+        return new CeremonyStepManager($steps);
+    }
+
+    public function requestCeremony(): CeremonyStepManager
+    {
+        $originStep = $this->allowedOrigins === null
+            ? new CheckOrigin($this->securedRelyingPartyId ?? [])
+            : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains);
+
+        return new CeremonyStepManager([
+            new CheckAllowedCredentialList(),
+            new CheckUserHandle(),
+            new CheckClientDataCollectorType(),
+            new CheckChallenge(),
+            $originStep,
+            new CheckTopOrigin(),
+            new CheckRelyingPartyIdIdHash(),
+            new CheckUserWasPresent(),
+            new CheckUserVerification(),
+            new CheckBackupBitsAreConsistent(),
+            new CheckExtensions($this->extensionOutputCheckerHandler),
+            new CheckSignature($this->algorithmManager),
+            new CheckCounter($this->counterChecker),
+        ]);
+    }
+}

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -156,11 +156,16 @@ final class SurfnetCeremonyStepManagerFactory
     // and requestCeremony() against these lists and port any new or reordered steps.
     public function creationCeremony(): CeremonyStepManager
     {
+        if ($this->metadataStatementRepository === null || $this->statusReportRepository === null) {
+            throw new \LogicException(
+                'MDS must be configured before calling creationCeremony(). ' .
+                'Call enableMetadataStatementSupport() first.'
+            );
+        }
+
         $metadataStatementChecker = new CheckMetadataStatement();
         if ($this->certificateChainValidator !== null) {
             $metadataStatementChecker->enableCertificateChainValidator($this->certificateChainValidator);
-        }
-        if ($this->metadataStatementRepository !== null && $this->statusReportRepository !== null && $this->certificateChainValidator !== null) {
             $metadataStatementChecker->enableMetadataStatementSupport(
                 $this->metadataStatementRepository,
                 $this->statusReportRepository,
@@ -172,7 +177,7 @@ final class SurfnetCeremonyStepManagerFactory
             ? new CheckOrigin($this->securedRelyingPartyId ?? [])
             : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains);
 
-        $steps = [
+        return new CeremonyStepManager([
             new CheckClientDataCollectorType(),
             new CheckChallenge(),
             $originStep,
@@ -188,16 +193,9 @@ final class SurfnetCeremonyStepManagerFactory
             $metadataStatementChecker,
             new CheckCredentialId(),
             new CheckAttestationIsNotNone(),
-        ];
-
-        if ($this->metadataStatementRepository !== null) {
-            $steps[] = new CheckHardwareKeyProtection($this->metadataStatementRepository);
-        }
-        if ($this->statusReportRepository !== null) {
-            $steps[] = new CheckFidoCertified($this->statusReportRepository);
-        }
-
-        return new CeremonyStepManager($steps);
+            new CheckHardwareKeyProtection($this->metadataStatementRepository),
+            new CheckFidoCertified($this->statusReportRepository),
+        ]);
     }
 
     public function requestCeremony(): CeremonyStepManager

--- a/src/Entity/PublicKeyCredentialSource.php
+++ b/src/Entity/PublicKeyCredentialSource.php
@@ -79,4 +79,9 @@ class PublicKeyCredentialSource extends BasePublicKeyCredentialSource
     {
         return $this->id;
     }
+
+    public function getFmt(): string
+    {
+        return $this->fmt;
+    }
 }

--- a/tests/Integration/CeremonyStep/CeremonyStepManagerFactoryWiringTest.php
+++ b/tests/Integration/CeremonyStep/CeremonyStepManagerFactoryWiringTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Integration\CeremonyStep;
+
+use Surfnet\Webauthn\CeremonyStep\SurfnetCeremonyStepManagerFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Webauthn\CeremonyStep\CeremonyStepManager;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+
+/**
+ * Verifies that the Symfony container correctly wires SurfnetCeremonyStepManagerFactory.
+ * Catches DI misconfiguration that manual construction in other tests cannot detect.
+ */
+class CeremonyStepManagerFactoryWiringTest extends KernelTestCase
+{
+    public function test_factory_resolves_to_surfnet_implementation(): void
+    {
+        self::bootKernel();
+
+        $factory = static::getContainer()->get(CeremonyStepManagerFactory::class);
+
+        $this->assertInstanceOf(SurfnetCeremonyStepManagerFactory::class, $factory);
+    }
+
+    public function test_creation_ceremony_builds_without_error(): void
+    {
+        self::bootKernel();
+
+        /** @var SurfnetCeremonyStepManagerFactory $factory */
+        $factory = static::getContainer()->get(CeremonyStepManagerFactory::class);
+
+        $this->assertInstanceOf(CeremonyStepManager::class, $factory->creationCeremony());
+    }
+
+    public function test_request_ceremony_builds_without_error(): void
+    {
+        self::bootKernel();
+
+        /** @var SurfnetCeremonyStepManagerFactory $factory */
+        $factory = static::getContainer()->get(CeremonyStepManagerFactory::class);
+
+        $this->assertInstanceOf(CeremonyStepManager::class, $factory->requestCeremony());
+    }
+}

--- a/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
+++ b/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
@@ -20,14 +20,9 @@ declare(strict_types=1);
 
 namespace Test\Integration\CeremonyStep;
 
-use CBOR\ByteStringObject;
-use CBOR\MapObject;
-use CBOR\NegativeIntegerObject;
-use CBOR\UnsignedIntegerObject;
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Algorithms;
-use OpenSSLAsymmetricKey;
 use PHPUnit\Framework\TestCase;
 use Surfnet\Webauthn\CeremonyStep\SurfnetCeremonyStepManagerFactory;
 use Symfony\Component\Uid\Uuid;
@@ -66,6 +61,17 @@ class FullRegistrationCeremonyTest extends TestCase
     private const RP_ID = 'example.com';
     private const ORIGIN = 'https://example.com';
     private const TEST_AAGUID = '550e8400-e29b-41d4-a716-446655440000';
+
+    private const TEST_PRIVATE_KEY_PEM = <<<PEM
+    -----BEGIN PRIVATE KEY-----
+    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgbKkXB055IwqO6IlK
+    IROwqe+eQY6ljMNghk/Oe7tOkDChRANCAATcLAujig+aLAX3qCZu52B9yEYTnHxG
+    YqXiBjNzHVOUMqQpbhYW7DYoZzRH3ByNp/KWay02kv+V6cS/YcKBfxIn
+    -----END PRIVATE KEY-----
+    PEM;
+
+    // Pre-computed COSE public key for TEST_PRIVATE_KEY_PEM (P-256, ES256)
+    private const TEST_COSE_PUBLIC_KEY = 'pQECAyYgASFYINwsC6OKD5osBfeoJm7nYH3IRhOcfEZipeIGM3MdU5QyIlggpCluFhbsNihnNEfcHI2n8pZrLTaS/5XpxL9hwoF/Eic=';
 
     private const FLAGS_NORMAL = AuthenticatorData::FLAG_UP | AuthenticatorData::FLAG_UV | AuthenticatorData::FLAG_AT;
     private const FLAGS_BACKUP_ELIGIBLE = self::FLAGS_NORMAL | AuthenticatorData::FLAG_BE;
@@ -214,7 +220,7 @@ class FullRegistrationCeremonyTest extends TestCase
      */
     private function buildPackedRegistration(int $flags): array
     {
-        [$privateKey, $cosePublicKeyBytes] = $this->generateEcKeypair();
+        [$privateKey, $cosePublicKeyBytes] = $this->getTestKeypair();
         $credentialId = random_bytes(32);
         $challenge = random_bytes(32);
 
@@ -237,7 +243,7 @@ class FullRegistrationCeremonyTest extends TestCase
      */
     private function buildNoneAttestationRegistration(): array
     {
-        [, $cosePublicKeyBytes] = $this->generateEcKeypair();
+        [, $cosePublicKeyBytes] = $this->getTestKeypair();
         $credentialId = random_bytes(32);
         $challenge = random_bytes(32);
 
@@ -252,24 +258,14 @@ class FullRegistrationCeremonyTest extends TestCase
     }
 
     /**
-     * @return array{OpenSSLAsymmetricKey, string}
+     * @return array{\OpenSSLAsymmetricKey, string}
      */
-    private function generateEcKeypair(): array
+    private function getTestKeypair(): array
     {
-        $privateKey = openssl_pkey_new(['curve_name' => 'prime256v1', 'private_key_type' => OPENSSL_KEYTYPE_EC]);
-        $details = openssl_pkey_get_details($privateKey);
-
-        $x = str_pad($details['ec']['x'], 32, "\x00", STR_PAD_LEFT);
-        $y = str_pad($details['ec']['y'], 32, "\x00", STR_PAD_LEFT);
-
-        $cosePublicKeyBytes = (string) MapObject::create()
-            ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))
-            ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))
-            ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))
-            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($x))
-            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($y));
-
-        return [$privateKey, $cosePublicKeyBytes];
+        return [
+            openssl_pkey_get_private(self::TEST_PRIVATE_KEY_PEM),
+            base64_decode(self::TEST_COSE_PUBLIC_KEY),
+        ];
     }
 
     private function buildAuthData(string $aaguid, int $flags, string $credentialId, string $coseKeyBytes): string

--- a/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
+++ b/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
@@ -1,0 +1,400 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Integration\CeremonyStep;
+
+use CBOR\ByteStringObject;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Manager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithms;
+use OpenSSLAsymmetricKey;
+use PHPUnit\Framework\TestCase;
+use Surfnet\Webauthn\CeremonyStep\SurfnetCeremonyStepManagerFactory;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestedCredentialData;
+use Webauthn\AttestationStatement\AttestationObject;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\PackedAttestationStatementSupport;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorData;
+use Webauthn\CollectedClientData;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
+use Webauthn\MetadataService\MetadataStatementRepository;
+use Webauthn\MetadataService\Statement\AuthenticatorStatus;
+use Webauthn\MetadataService\Statement\MetadataStatement;
+use Webauthn\MetadataService\Statement\StatusReport;
+use Webauthn\MetadataService\StatusReportRepository;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\PublicKeyCredentialUserEntity;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * Full end-to-end registration ceremony test using real EC P-256 crypto.
+ *
+ * These tests replace the reflection-based step-list check in the unit tests:
+ * if the factory wires steps in the wrong order, or a library upgrade silently
+ * changes ceremony behaviour, these tests will fail with real crypto evidence.
+ */
+class FullRegistrationCeremonyTest extends TestCase
+{
+    private const RP_ID = 'example.com';
+    private const ORIGIN = 'https://example.com';
+    private const TEST_AAGUID = '550e8400-e29b-41d4-a716-446655440000';
+
+    private const FLAGS_NORMAL = AuthenticatorData::FLAG_UP | AuthenticatorData::FLAG_UV | AuthenticatorData::FLAG_AT;
+    private const FLAGS_BACKUP_ELIGIBLE = self::FLAGS_NORMAL | AuthenticatorData::FLAG_BE;
+
+    public function test_valid_hardware_token_registration_passes(): void
+    {
+        [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
+
+        $validator = $this->buildValidator(
+            mdsRepo: $this->hardwareMdsRepo(self::TEST_AAGUID),
+            statusRepo: $this->fidoCertifiedStatusRepo(self::TEST_AAGUID),
+        );
+
+        $result = $validator->check($response, $options, self::RP_ID);
+
+        $this->assertInstanceOf(PublicKeyCredentialSource::class, $result);
+    }
+
+    public function test_backup_eligible_credential_is_rejected(): void
+    {
+        [$response, $options] = $this->buildPackedRegistration(self::FLAGS_BACKUP_ELIGIBLE);
+
+        $validator = $this->buildValidator(
+            mdsRepo: $this->hardwareMdsRepo(self::TEST_AAGUID),
+            statusRepo: $this->fidoCertifiedStatusRepo(self::TEST_AAGUID),
+        );
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $validator->check($response, $options, self::RP_ID);
+    }
+
+    public function test_none_attestation_is_rejected(): void
+    {
+        [$response, $options] = $this->buildNoneAttestationRegistration();
+
+        $validator = $this->buildValidator(
+            mdsRepo: $this->hardwareMdsRepo(self::TEST_AAGUID),
+            statusRepo: $this->fidoCertifiedStatusRepo(self::TEST_AAGUID),
+        );
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $validator->check($response, $options, self::RP_ID);
+    }
+
+    public function test_no_fido_status_reports_is_rejected(): void
+    {
+        [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
+
+        $aaguid = self::TEST_AAGUID;
+        $emptyStatusRepo = new class ($aaguid) implements StatusReportRepository {
+            public function __construct(private readonly string $aaguid)
+            {
+            }
+
+            /** @return StatusReport[] */
+            public function findStatusReportsByAAGUID(string $aaguid): array
+            {
+                return [];
+            }
+        };
+
+        $validator = $this->buildValidator(
+            mdsRepo: $this->hardwareMdsRepo(self::TEST_AAGUID),
+            statusRepo: $emptyStatusRepo,
+        );
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $validator->check($response, $options, self::RP_ID);
+    }
+
+    public function test_not_fido_certified_is_rejected(): void
+    {
+        [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
+
+        $aaguid = self::TEST_AAGUID;
+        $revokedStatusRepo = new class ($aaguid) implements StatusReportRepository {
+            public function __construct(private readonly string $aaguid)
+            {
+            }
+
+            /** @return StatusReport[] */
+            public function findStatusReportsByAAGUID(string $aaguid): array
+            {
+                if ($aaguid !== $this->aaguid) {
+                    return [];
+                }
+                return [StatusReport::create(AuthenticatorStatus::NOT_FIDO_CERTIFIED, null, null, null, null, null, null, null)];
+            }
+        };
+
+        $validator = $this->buildValidator(
+            mdsRepo: $this->hardwareMdsRepo(self::TEST_AAGUID),
+            statusRepo: $revokedStatusRepo,
+        );
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $validator->check($response, $options, self::RP_ID);
+    }
+
+    public function test_software_key_is_rejected(): void
+    {
+        [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
+
+        $aaguid = self::TEST_AAGUID;
+        $softwareMdsRepo = new class ($aaguid) implements MetadataStatementRepository {
+            public function __construct(private readonly string $aaguid)
+            {
+            }
+
+            public function findOneByAAGUID(string $aaguid): ?MetadataStatement
+            {
+                if ($aaguid !== $this->aaguid) {
+                    return null;
+                }
+                return MetadataStatement::create(
+                    'Software Authenticator',
+                    1,
+                    'fido2',
+                    3,
+                    [],
+                    [],
+                    [],
+                    ['basic_full'],
+                    [],
+                    [],
+                    [],
+                    [],
+                    keyProtection: [MetadataStatement::KEY_PROTECTION_SOFTWARE],
+                );
+            }
+        };
+
+        $validator = $this->buildValidator(
+            mdsRepo: $softwareMdsRepo,
+            statusRepo: $this->fidoCertifiedStatusRepo(self::TEST_AAGUID),
+        );
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+        $validator->check($response, $options, self::RP_ID);
+    }
+
+    // --- Fixture builders ---
+
+    /**
+     * @return array{AuthenticatorAttestationResponse, PublicKeyCredentialCreationOptions}
+     */
+    private function buildPackedRegistration(int $flags): array
+    {
+        [$privateKey, $cosePublicKeyBytes] = $this->generateEcKeypair();
+        $credentialId = random_bytes(32);
+        $challenge = random_bytes(32);
+
+        $authDataBytes = $this->buildAuthData(self::TEST_AAGUID, $flags, $credentialId, $cosePublicKeyBytes);
+        $clientDataJSON = $this->buildClientDataJson($challenge);
+        $clientDataJSONHash = hash('sha256', $clientDataJSON, true);
+
+        $dataToSign = $authDataBytes . $clientDataJSONHash;
+        openssl_sign($dataToSign, $signature, $privateKey, OPENSSL_ALGO_SHA256);
+
+        $attStmt = AttestationStatement::createSelf('packed', ['alg' => -7, 'sig' => $signature], new EmptyTrustPath());
+        $response = $this->buildResponse($authDataBytes, $flags, $credentialId, $cosePublicKeyBytes, $attStmt, $clientDataJSON);
+        $options = $this->buildCreationOptions($challenge);
+
+        return [$response, $options];
+    }
+
+    /**
+     * @return array{AuthenticatorAttestationResponse, PublicKeyCredentialCreationOptions}
+     */
+    private function buildNoneAttestationRegistration(): array
+    {
+        [, $cosePublicKeyBytes] = $this->generateEcKeypair();
+        $credentialId = random_bytes(32);
+        $challenge = random_bytes(32);
+
+        $authDataBytes = $this->buildAuthData(self::TEST_AAGUID, self::FLAGS_NORMAL, $credentialId, $cosePublicKeyBytes);
+        $clientDataJSON = $this->buildClientDataJson($challenge);
+
+        $attStmt = AttestationStatement::createNone('none', [], new EmptyTrustPath());
+        $response = $this->buildResponse($authDataBytes, self::FLAGS_NORMAL, $credentialId, $cosePublicKeyBytes, $attStmt, $clientDataJSON);
+        $options = $this->buildCreationOptions($challenge);
+
+        return [$response, $options];
+    }
+
+    /**
+     * @return array{OpenSSLAsymmetricKey, string}
+     */
+    private function generateEcKeypair(): array
+    {
+        $privateKey = openssl_pkey_new(['curve_name' => 'prime256v1', 'private_key_type' => OPENSSL_KEYTYPE_EC]);
+        $details = openssl_pkey_get_details($privateKey);
+
+        $cosePublicKeyBytes = (string) MapObject::create()
+            ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))
+            ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))
+            ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))
+            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($details['ec']['x']))
+            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($details['ec']['y']));
+
+        return [$privateKey, $cosePublicKeyBytes];
+    }
+
+    private function buildAuthData(string $aaguid, int $flags, string $credentialId, string $coseKeyBytes): string
+    {
+        $rpIdHash = hash('sha256', self::RP_ID, true);
+        $flagsByte = chr($flags);
+        $signCount = pack('N', 0);
+        $aaguidBytes = hex2bin(str_replace('-', '', $aaguid));
+        $credentialIdLength = pack('n', strlen($credentialId));
+
+        return $rpIdHash . $flagsByte . $signCount . $aaguidBytes . $credentialIdLength . $credentialId . $coseKeyBytes;
+    }
+
+    private function buildClientDataJson(string $challenge): string
+    {
+        $challengeBase64 = sodium_bin2base64($challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        return (string) json_encode([
+            'type' => 'webauthn.create',
+            'challenge' => $challengeBase64,
+            'origin' => self::ORIGIN,
+        ]);
+    }
+
+    private function buildResponse(
+        string $authDataBytes,
+        int $flags,
+        string $credentialId,
+        string $cosePublicKeyBytes,
+        AttestationStatement $attStmt,
+        string $clientDataJSON
+    ): AuthenticatorAttestationResponse {
+        $aaguid = Uuid::fromString(self::TEST_AAGUID);
+        $attestedCredentialData = AttestedCredentialData::create($aaguid, $credentialId, $cosePublicKeyBytes);
+        $authData = AuthenticatorData::create(
+            $authDataBytes,
+            hash('sha256', self::RP_ID, true),
+            chr($flags),
+            0,
+            $attestedCredentialData,
+        );
+        $attestationObject = AttestationObject::create('', $attStmt, $authData);
+        $collectedClientData = CollectedClientData::create($clientDataJSON, (array) json_decode($clientDataJSON, true));
+
+        return AuthenticatorAttestationResponse::create($collectedClientData, $attestationObject);
+    }
+
+    private function buildCreationOptions(string $challenge): PublicKeyCredentialCreationOptions
+    {
+        $rp = PublicKeyCredentialRpEntity::create(self::RP_ID, self::RP_ID);
+        $user = PublicKeyCredentialUserEntity::create('user', 'user-handle', 'User');
+
+        return PublicKeyCredentialCreationOptions::create($rp, $user, $challenge, [
+            PublicKeyCredentialParameters::createPk(Algorithms::COSE_ALGORITHM_ES256),
+        ]);
+    }
+
+    // --- MDS helpers ---
+
+    private function buildValidator(
+        MetadataStatementRepository $mdsRepo,
+        StatusReportRepository $statusRepo,
+    ): AuthenticatorAttestationResponseValidator {
+        $certChainValidator = new class implements CertificateChainValidator {
+            public function check(array $untrustedCertificates, array $trustedCertificates): void
+            {
+            }
+        };
+
+        $factory = new SurfnetCeremonyStepManagerFactory();
+        $factory->setAllowedOrigins([self::ORIGIN]);
+        $factory->setAttestationStatementSupportManager(
+            new AttestationStatementSupportManager([
+                new PackedAttestationStatementSupport(
+                    Manager::create()->add(ES256::create())
+                ),
+            ])
+        );
+        $factory->enableMetadataStatementSupport($mdsRepo, $statusRepo, $certChainValidator);
+
+        return new AuthenticatorAttestationResponseValidator($factory->creationCeremony());
+    }
+
+    private function hardwareMdsRepo(string $aaguid): MetadataStatementRepository
+    {
+        return new class ($aaguid) implements MetadataStatementRepository {
+            public function __construct(private readonly string $aaguid)
+            {
+            }
+
+            public function findOneByAAGUID(string $aaguid): ?MetadataStatement
+            {
+                if ($aaguid !== $this->aaguid) {
+                    return null;
+                }
+                return MetadataStatement::create(
+                    'Test Hardware Authenticator',
+                    1,
+                    'fido2',
+                    3,
+                    [],
+                    [],
+                    [],
+                    ['basic_full'],
+                    [],
+                    [],
+                    [],
+                    [],
+                    keyProtection: [MetadataStatement::KEY_PROTECTION_HARDWARE],
+                );
+            }
+        };
+    }
+
+    private function fidoCertifiedStatusRepo(string $aaguid): StatusReportRepository
+    {
+        return new class ($aaguid) implements StatusReportRepository {
+            public function __construct(private readonly string $aaguid)
+            {
+            }
+
+            /** @return StatusReport[] */
+            public function findStatusReportsByAAGUID(string $aaguid): array
+            {
+                if ($aaguid !== $this->aaguid) {
+                    return [];
+                }
+                return [StatusReport::create(AuthenticatorStatus::FIDO_CERTIFIED, '2024-01-01', null, null, null, null, null, null)];
+            }
+        };
+    }
+}

--- a/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
+++ b/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
@@ -335,7 +335,7 @@ class FullRegistrationCeremonyTest extends TestCase
             }
         };
 
-        $factory = new SurfnetCeremonyStepManagerFactory();
+        $factory = new SurfnetCeremonyStepManagerFactory($mdsRepo, $statusRepo, $certChainValidator);
         $factory->setAllowedOrigins([self::ORIGIN]);
         $factory->setAttestationStatementSupportManager(
             new AttestationStatementSupportManager([
@@ -344,7 +344,6 @@ class FullRegistrationCeremonyTest extends TestCase
                 ),
             ])
         );
-        $factory->enableMetadataStatementSupport($mdsRepo, $statusRepo, $certChainValidator);
 
         return new AuthenticatorAttestationResponseValidator($factory->creationCeremony());
     }

--- a/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
+++ b/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
@@ -76,7 +76,7 @@ class FullRegistrationCeremonyTest extends TestCase
     private const FLAGS_NORMAL = AuthenticatorData::FLAG_UP | AuthenticatorData::FLAG_UV | AuthenticatorData::FLAG_AT;
     private const FLAGS_BACKUP_ELIGIBLE = self::FLAGS_NORMAL | AuthenticatorData::FLAG_BE;
 
-    public function test_valid_hardware_token_registration_passes(): void
+    public function testValidHardwareTokenRegistrationPasses(): void
     {
         [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
 
@@ -90,7 +90,7 @@ class FullRegistrationCeremonyTest extends TestCase
         $this->assertInstanceOf(PublicKeyCredentialSource::class, $result);
     }
 
-    public function test_backup_eligible_credential_is_rejected(): void
+    public function testBackupEligibleCredentialIsRejected(): void
     {
         [$response, $options] = $this->buildPackedRegistration(self::FLAGS_BACKUP_ELIGIBLE);
 
@@ -103,7 +103,7 @@ class FullRegistrationCeremonyTest extends TestCase
         $validator->check($response, $options, self::RP_ID);
     }
 
-    public function test_none_attestation_is_rejected(): void
+    public function testNoneAttestationIsRejected(): void
     {
         [$response, $options] = $this->buildNoneAttestationRegistration();
 
@@ -116,67 +116,37 @@ class FullRegistrationCeremonyTest extends TestCase
         $validator->check($response, $options, self::RP_ID);
     }
 
-    public function test_no_fido_status_reports_is_rejected(): void
+    public function testNoFidoStatusReportsIsRejected(): void
     {
         [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
 
-        $aaguid = self::TEST_AAGUID;
-        $emptyStatusRepo = new class ($aaguid) implements StatusReportRepository {
-            public function __construct(private readonly string $aaguid)
-            {
-            }
-
-            /** @return StatusReport[] */
-            public function findStatusReportsByAAGUID(string $aaguid): array
-            {
-                return [];
-            }
-        };
-
         $validator = $this->buildValidator(
             mdsRepo: $this->hardwareMdsRepo(self::TEST_AAGUID),
-            statusRepo: $emptyStatusRepo,
+            statusRepo: $this->emptyStatusRepo(self::TEST_AAGUID),
         );
 
         $this->expectException(AuthenticatorResponseVerificationException::class);
         $validator->check($response, $options, self::RP_ID);
     }
 
-    public function test_not_fido_certified_is_rejected(): void
+    public function testNotFidoCertifiedIsRejected(): void
     {
         [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
 
-        $aaguid = self::TEST_AAGUID;
-        $revokedStatusRepo = new class ($aaguid) implements StatusReportRepository {
-            public function __construct(private readonly string $aaguid)
-            {
-            }
-
-            /** @return StatusReport[] */
-            public function findStatusReportsByAAGUID(string $aaguid): array
-            {
-                if ($aaguid !== $this->aaguid) {
-                    return [];
-                }
-                return [StatusReport::create(AuthenticatorStatus::NOT_FIDO_CERTIFIED, null, null, null, null, null, null, null)];
-            }
-        };
-
         $validator = $this->buildValidator(
             mdsRepo: $this->hardwareMdsRepo(self::TEST_AAGUID),
-            statusRepo: $revokedStatusRepo,
+            statusRepo: $this->notFidoCertifiedStatusRepo(self::TEST_AAGUID),
         );
 
         $this->expectException(AuthenticatorResponseVerificationException::class);
         $validator->check($response, $options, self::RP_ID);
     }
 
-    public function test_software_key_is_rejected(): void
+    public function testSoftwareKeyIsRejected(): void
     {
         [$response, $options] = $this->buildPackedRegistration(self::FLAGS_NORMAL);
 
-        $aaguid = self::TEST_AAGUID;
-        $softwareMdsRepo = new class ($aaguid) implements MetadataStatementRepository {
+        $softwareMdsRepo = new class (self::TEST_AAGUID) implements MetadataStatementRepository {
             public function __construct(private readonly string $aaguid)
             {
             }
@@ -345,6 +315,39 @@ class FullRegistrationCeremonyTest extends TestCase
         );
 
         return new AuthenticatorAttestationResponseValidator($factory->creationCeremony());
+    }
+
+    private function emptyStatusRepo(string $aaguid): StatusReportRepository
+    {
+        return new class ($aaguid) implements StatusReportRepository {
+            public function __construct(private readonly string $aaguid)
+            {
+            }
+
+            /** @return StatusReport[] */
+            public function findStatusReportsByAAGUID(string $aaguid): array
+            {
+                return [];
+            }
+        };
+    }
+
+    private function notFidoCertifiedStatusRepo(string $aaguid): StatusReportRepository
+    {
+        return new class ($aaguid) implements StatusReportRepository {
+            public function __construct(private readonly string $aaguid)
+            {
+            }
+
+            /** @return StatusReport[] */
+            public function findStatusReportsByAAGUID(string $aaguid): array
+            {
+                if ($aaguid !== $this->aaguid) {
+                    return [];
+                }
+                return [StatusReport::create(AuthenticatorStatus::NOT_FIDO_CERTIFIED, null, null, null, null, null, null, null)];
+            }
+        };
     }
 
     private function hardwareMdsRepo(string $aaguid): MetadataStatementRepository

--- a/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
+++ b/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
@@ -42,6 +42,7 @@ use Webauthn\MetadataService\Statement\AuthenticatorStatus;
 use Webauthn\MetadataService\Statement\MetadataStatement;
 use Webauthn\MetadataService\Statement\StatusReport;
 use Webauthn\MetadataService\StatusReportRepository;
+use Psr\Log\NullLogger;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRpEntity;
@@ -304,7 +305,7 @@ class FullRegistrationCeremonyTest extends TestCase
             }
         };
 
-        $factory = new SurfnetCeremonyStepManagerFactory($mdsRepo, $statusRepo, $certChainValidator);
+        $factory = new SurfnetCeremonyStepManagerFactory(new NullLogger(), $mdsRepo, $statusRepo, $certChainValidator);
         $factory->setAllowedOrigins([self::ORIGIN]);
         $factory->setAttestationStatementSupportManager(
             new AttestationStatementSupportManager([

--- a/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
+++ b/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
@@ -259,12 +259,15 @@ class FullRegistrationCeremonyTest extends TestCase
         $privateKey = openssl_pkey_new(['curve_name' => 'prime256v1', 'private_key_type' => OPENSSL_KEYTYPE_EC]);
         $details = openssl_pkey_get_details($privateKey);
 
+        $x = str_pad($details['ec']['x'], 32, "\x00", STR_PAD_LEFT);
+        $y = str_pad($details['ec']['y'], 32, "\x00", STR_PAD_LEFT);
+
         $cosePublicKeyBytes = (string) MapObject::create()
             ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))
             ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))
             ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))
-            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($details['ec']['x']))
-            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($details['ec']['y']));
+            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($x))
+            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($y));
 
         return [$privateKey, $cosePublicKeyBytes];
     }

--- a/tests/Unit/CeremonyStep/AbstractCeremonyStepTestCase.php
+++ b/tests/Unit/CeremonyStep/AbstractCeremonyStepTestCase.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestationStatement\AttestationObject;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AttestedCredentialData;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorData;
+use Webauthn\CollectedClientData;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+abstract class AbstractCeremonyStepTestCase extends TestCase
+{
+    protected PublicKeyCredentialSource $credentialSource;
+    protected PublicKeyCredentialRequestOptions $options;
+
+    protected function setUp(): void
+    {
+        $this->credentialSource = $this->createMock(PublicKeyCredentialSource::class);
+        $this->options = PublicKeyCredentialRequestOptions::create('challenge');
+    }
+
+    protected function makeAttestedCredentialData(): AttestedCredentialData
+    {
+        return AttestedCredentialData::create(
+            Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+            'credential-id',
+            null
+        );
+    }
+
+    protected function buildAttestationResponse(
+        ?AttestedCredentialData $attestedCredentialData = null,
+        string $attStmtType = AttestationStatement::TYPE_BASIC,
+        bool $backupEligible = false
+    ): AuthenticatorAttestationResponse {
+        $flags = AuthenticatorData::FLAG_UP;
+        if ($backupEligible) {
+            $flags |= AuthenticatorData::FLAG_BE;
+        }
+        if ($attestedCredentialData !== null) {
+            $flags |= AuthenticatorData::FLAG_AT;
+        }
+
+        $attStmt = AttestationStatement::create('packed', [], $attStmtType, EmptyTrustPath::create());
+        $authData = AuthenticatorData::create(str_repeat("\x00", 37), str_repeat("\x00", 32), chr($flags), 0, $attestedCredentialData);
+        $attestationObject = AttestationObject::create('raw', $attStmt, $authData);
+        $clientData = CollectedClientData::create('raw', ['type' => 'webauthn.create', 'challenge' => 'dGVzdA', 'origin' => 'https://example.com']);
+
+        return new AuthenticatorAttestationResponse($clientData, $attestationObject);
+    }
+}

--- a/tests/Unit/CeremonyStep/CheckAttestationIsNotNoneTest.php
+++ b/tests/Unit/CeremonyStep/CheckAttestationIsNotNoneTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Surfnet\Webauthn\CeremonyStep\CheckAttestationIsNotNone;
+use Webauthn\AttestationStatement\AttestationStatement;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+
+class CheckAttestationIsNotNoneTest extends AbstractCeremonyStepTestCase
+{
+    private CheckAttestationIsNotNone $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->step = new CheckAttestationIsNotNone();
+    }
+
+    public function test_skips_assertion_response(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_throws_for_type_none(): void
+    {
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(attStmtType: AttestationStatement::TYPE_NONE),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_passes_for_type_basic(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(attStmtType: AttestationStatement::TYPE_BASIC),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/CeremonyStep/CheckAttestationIsNotNoneTest.php
+++ b/tests/Unit/CeremonyStep/CheckAttestationIsNotNoneTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckAttestationIsNotNone;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AuthenticatorAssertionResponse;
@@ -32,7 +33,7 @@ class CheckAttestationIsNotNoneTest extends AbstractCeremonyStepTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->step = new CheckAttestationIsNotNone();
+        $this->step = new CheckAttestationIsNotNone(new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
+++ b/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckFidoCertified;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
@@ -36,7 +37,7 @@ class CheckFidoCertifiedTest extends AbstractCeremonyStepTestCase
     {
         parent::setUp();
         $this->repository = $this->createMock(StatusReportRepository::class);
-        $this->step = new CheckFidoCertified($this->repository);
+        $this->step = new CheckFidoCertified($this->repository, new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
+++ b/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
@@ -84,6 +84,28 @@ class CheckFidoCertifiedTest extends AbstractCeremonyStepTestCase
         );
     }
 
+    public function test_rejects_ctap1_u2f_authenticators_with_null_aaguid(): void
+    {
+        // CTAP1/U2F authenticators advertise the null UUID (00000000-...) as their AAGUID.
+        // They have no FIDO MDS status reports, so they are always rejected here.
+        // This is the primary safety net for authenticators absent from the MDS.
+        $this->repository
+            ->expects($this->once())
+            ->method('findStatusReportsByAAGUID')
+            ->with('00000000-0000-0000-0000-000000000000')
+            ->willReturn([]);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
     /** @dataProvider fidoCertifiedStatusProvider */
     public function test_passes_for_all_fido_certified_levels(string $status): void
     {

--- a/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
+++ b/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Surfnet\Webauthn\CeremonyStep\CheckFidoCertified;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\MetadataService\Statement\AuthenticatorStatus;
+use Webauthn\MetadataService\Statement\StatusReport;
+use Webauthn\MetadataService\StatusReportRepository;
+
+class CheckFidoCertifiedTest extends AbstractCeremonyStepTestCase
+{
+    private StatusReportRepository $repository;
+    private CheckFidoCertified $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = $this->createMock(StatusReportRepository::class);
+        $this->step = new CheckFidoCertified($this->repository);
+    }
+
+    public function test_skips_assertion_response(): void
+    {
+        $this->repository->expects($this->never())->method('findStatusReportsByAAGUID');
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_skips_when_no_attested_credential_data(): void
+    {
+        $this->repository->expects($this->never())->method('findStatusReportsByAAGUID');
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_throws_when_no_status_reports(): void
+    {
+        $this->repository->method('findStatusReportsByAAGUID')->willReturn([]);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    /** @dataProvider fidoCertifiedStatusProvider */
+    public function test_passes_for_all_fido_certified_levels(string $status): void
+    {
+        $this->repository->method('findStatusReportsByAAGUID')->willReturn([
+            $this->makeStatusReport($status),
+        ]);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function fidoCertifiedStatusProvider(): array
+    {
+        return [
+            'FIDO_CERTIFIED'        => [AuthenticatorStatus::FIDO_CERTIFIED],
+            'FIDO_CERTIFIED_L1'     => [AuthenticatorStatus::FIDO_CERTIFIED_L1],
+            'FIDO_CERTIFIED_L1plus' => [AuthenticatorStatus::FIDO_CERTIFIED_L1plus],
+            'FIDO_CERTIFIED_L2'     => [AuthenticatorStatus::FIDO_CERTIFIED_L2],
+            'FIDO_CERTIFIED_L2plus' => [AuthenticatorStatus::FIDO_CERTIFIED_L2plus],
+            'FIDO_CERTIFIED_L3'     => [AuthenticatorStatus::FIDO_CERTIFIED_L3],
+            'FIDO_CERTIFIED_L3plus' => [AuthenticatorStatus::FIDO_CERTIFIED_L3plus],
+            'FIDO_CERTIFIED_L4'     => [AuthenticatorStatus::FIDO_CERTIFIED_L4],
+            'FIDO_CERTIFIED_L5'     => [AuthenticatorStatus::FIDO_CERTIFIED_L5],
+        ];
+    }
+
+    public function test_throws_when_not_fido_certified(): void
+    {
+        $this->repository->method('findStatusReportsByAAGUID')->willReturn([
+            $this->makeStatusReport(AuthenticatorStatus::NOT_FIDO_CERTIFIED),
+        ]);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_uses_most_recent_report_by_effective_date(): void
+    {
+        // Newest-first order from the repository — sorting must pick the right one
+        $this->repository->method('findStatusReportsByAAGUID')->willReturn([
+            $this->makeStatusReport(AuthenticatorStatus::NOT_FIDO_CERTIFIED, '2024-01-01'),
+            $this->makeStatusReport(AuthenticatorStatus::FIDO_CERTIFIED, '2023-01-01'),
+        ]);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_throws_for_revoked_status(): void
+    {
+        $this->repository->method('findStatusReportsByAAGUID')->willReturn([
+            $this->makeStatusReport(AuthenticatorStatus::REVOKED),
+        ]);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_null_effective_date_is_treated_as_older_than_dated_report(): void
+    {
+        // Null-dated report (initial/undated) must sort before a dated newer report
+        $this->repository->method('findStatusReportsByAAGUID')->willReturn([
+            $this->makeStatusReport(AuthenticatorStatus::FIDO_CERTIFIED, '2024-01-01'),
+            $this->makeStatusReport(AuthenticatorStatus::NOT_FIDO_CERTIFIED, null),
+        ]);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function makeStatusReport(string $status, ?string $effectiveDate = null): StatusReport
+    {
+        return StatusReport::create($status, $effectiveDate, null, null, null, null, null, null);
+    }
+}

--- a/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
+++ b/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
@@ -70,6 +70,8 @@ class CheckHardwareKeyProtectionTest extends AbstractCeremonyStepTestCase
 
     public function test_skips_when_no_metadata_statement(): void
     {
+        // Authenticators absent from the MDS cannot have their key protection verified here.
+        // CheckFidoCertified is the safety net: it throws when no status reports exist for the AAGUID.
         $this->repository->method('findOneByAAGUID')->willReturn(null);
 
         $this->step->process(

--- a/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
+++ b/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckHardwareKeyProtection;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
@@ -35,7 +36,7 @@ class CheckHardwareKeyProtectionTest extends AbstractCeremonyStepTestCase
     {
         parent::setUp();
         $this->repository = $this->createMock(MetadataStatementRepository::class);
-        $this->step = new CheckHardwareKeyProtection($this->repository);
+        $this->step = new CheckHardwareKeyProtection($this->repository, new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
+++ b/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Surfnet\Webauthn\CeremonyStep\CheckHardwareKeyProtection;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\MetadataService\MetadataStatementRepository;
+use Webauthn\MetadataService\Statement\MetadataStatement;
+
+class CheckHardwareKeyProtectionTest extends AbstractCeremonyStepTestCase
+{
+    private MetadataStatementRepository $repository;
+    private CheckHardwareKeyProtection $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = $this->createMock(MetadataStatementRepository::class);
+        $this->step = new CheckHardwareKeyProtection($this->repository);
+    }
+
+    public function test_skips_assertion_response(): void
+    {
+        $this->repository->expects($this->never())->method('findOneByAAGUID');
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_skips_when_no_attested_credential_data(): void
+    {
+        $this->repository->expects($this->never())->method('findOneByAAGUID');
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_skips_when_no_metadata_statement(): void
+    {
+        $this->repository->method('findOneByAAGUID')->willReturn(null);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_passes_for_hardware_key_protection(): void
+    {
+        $metadata = $this->createMock(MetadataStatement::class);
+        $metadata->keyProtection = [MetadataStatement::KEY_PROTECTION_HARDWARE];
+        $this->repository->method('findOneByAAGUID')->willReturn($metadata);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_passes_for_secure_element_key_protection(): void
+    {
+        $metadata = $this->createMock(MetadataStatement::class);
+        $metadata->keyProtection = [MetadataStatement::KEY_PROTECTION_SECURE_ELEMENT];
+        $this->repository->method('findOneByAAGUID')->willReturn($metadata);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_throws_for_software_key_protection(): void
+    {
+        $metadata = $this->createMock(MetadataStatement::class);
+        $metadata->keyProtection = [MetadataStatement::KEY_PROTECTION_SOFTWARE];
+        $this->repository->method('findOneByAAGUID')->willReturn($metadata);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_throws_for_tee_key_protection(): void
+    {
+        $metadata = $this->createMock(MetadataStatement::class);
+        $metadata->keyProtection = [MetadataStatement::KEY_PROTECTION_TEE];
+        $this->repository->method('findOneByAAGUID')->willReturn($metadata);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_throws_for_empty_key_protection(): void
+    {
+        $metadata = $this->createMock(MetadataStatement::class);
+        $metadata->keyProtection = [];
+        $this->repository->method('findOneByAAGUID')->willReturn($metadata);
+
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+}

--- a/tests/Unit/CeremonyStep/CheckNoBackupEligibilityTest.php
+++ b/tests/Unit/CeremonyStep/CheckNoBackupEligibilityTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckNoBackupEligibility;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
@@ -31,7 +32,7 @@ class CheckNoBackupEligibilityTest extends AbstractCeremonyStepTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->step = new CheckNoBackupEligibility();
+        $this->step = new CheckNoBackupEligibility(new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/CheckNoBackupEligibilityTest.php
+++ b/tests/Unit/CeremonyStep/CheckNoBackupEligibilityTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Surfnet\Webauthn\CeremonyStep\CheckNoBackupEligibility;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
+
+class CheckNoBackupEligibilityTest extends AbstractCeremonyStepTestCase
+{
+    private CheckNoBackupEligibility $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->step = new CheckNoBackupEligibility();
+    }
+
+    public function test_skips_assertion_response(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_throws_when_backup_eligible(): void
+    {
+        $this->expectException(AuthenticatorResponseVerificationException::class);
+
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(backupEligible: true),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_passes_when_not_backup_eligible(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(backupEligible: false),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/CeremonyStep/LogAuthenticationDataTest.php
+++ b/tests/Unit/CeremonyStep/LogAuthenticationDataTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Surfnet\Webauthn\CeremonyStep\LogAuthenticationData;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestedCredentialData;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\PublicKeyCredentialSource;
+
+class LogAuthenticationDataTest extends AbstractCeremonyStepTestCase
+{
+    private LogAuthenticationData $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->step = new LogAuthenticationData(new NullLogger());
+    }
+
+    public function test_skips_attestation_response_without_logging(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+        $logger->expects($this->never())->method('warning');
+
+        $step = new LogAuthenticationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_info_for_known_aaguid(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info');
+        $logger->expects($this->never())->method('warning');
+
+        $credentialSource = $this->credentialSourceWithAaguid('550e8400-e29b-41d4-a716-446655440000');
+
+        $step = new LogAuthenticationData($logger);
+        $step->process(
+            $credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_warning_for_null_aaguid(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+        $logger->expects($this->once())->method('warning');
+
+        $credentialSource = $this->credentialSourceWithAaguid('00000000-0000-0000-0000-000000000000');
+
+        $step = new LogAuthenticationData($logger);
+        $step->process(
+            $credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_never_throws(): void
+    {
+        $credentialSource = $this->credentialSourceWithAaguid('00000000-0000-0000-0000-000000000000');
+
+        $this->step->process(
+            $credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function credentialSourceWithAaguid(string $uuid): PublicKeyCredentialSource
+    {
+        return PublicKeyCredentialSource::create(
+            'credential-id',
+            'public-key',
+            [],
+            'basic',
+            new \Webauthn\TrustPath\EmptyTrustPath(),
+            Uuid::fromString($uuid),
+            'public-key-bytes',
+            'user-handle',
+            0,
+        );
+    }
+}

--- a/tests/Unit/CeremonyStep/LogRegistrationDataTest.php
+++ b/tests/Unit/CeremonyStep/LogRegistrationDataTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Surfnet\Webauthn\CeremonyStep\LogRegistrationData;
+use Webauthn\AuthenticatorAssertionResponse;
+
+class LogRegistrationDataTest extends AbstractCeremonyStepTestCase
+{
+    private LogRegistrationData $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->step = new LogRegistrationData(new NullLogger());
+    }
+
+    public function test_skips_assertion_response_without_logging(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+
+
+        $step = new LogRegistrationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_info_for_attestation_response(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('info');
+
+        $step = new LogRegistrationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_raw_attestation_data_at_info(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))->method('info');
+
+        $step = new LogRegistrationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_never_throws(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_never_throws_without_attested_credential_data(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
+++ b/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Surfnet\Webauthn\CeremonyStep\CheckAttestationIsNotNone;
+use Surfnet\Webauthn\CeremonyStep\CheckFidoCertified;
+use Surfnet\Webauthn\CeremonyStep\CheckHardwareKeyProtection;
+use Surfnet\Webauthn\CeremonyStep\CheckNoBackupEligibility;
+use Surfnet\Webauthn\CeremonyStep\SurfnetCeremonyStepManagerFactory;
+use Webauthn\CeremonyStep\CeremonyStepManager;
+use Webauthn\CeremonyStep\CheckAlgorithm;
+use Webauthn\CeremonyStep\CheckAllowedCredentialList;
+use Webauthn\CeremonyStep\CheckAttestationFormatIsKnownAndValid;
+use Webauthn\CeremonyStep\CheckBackupBitsAreConsistent;
+use Webauthn\CeremonyStep\CheckChallenge;
+use Webauthn\CeremonyStep\CheckClientDataCollectorType;
+use Webauthn\CeremonyStep\CheckCounter;
+use Webauthn\CeremonyStep\CheckCredentialId;
+use Webauthn\CeremonyStep\CheckExtensions;
+use Webauthn\CeremonyStep\CheckHasAttestedCredentialData;
+use Webauthn\CeremonyStep\CheckMetadataStatement;
+use Webauthn\CeremonyStep\CheckOrigin;
+use Webauthn\CeremonyStep\CheckRelyingPartyIdIdHash;
+use Webauthn\CeremonyStep\CheckSignature;
+use Webauthn\CeremonyStep\CheckTopOrigin;
+use Webauthn\CeremonyStep\CheckUserHandle;
+use Webauthn\CeremonyStep\CheckUserVerification;
+use Webauthn\CeremonyStep\CheckUserWasPresent;
+use Webauthn\MetadataService\CertificateChain\CertificateChainValidator;
+use Webauthn\MetadataService\MetadataStatementRepository;
+use Webauthn\MetadataService\StatusReportRepository;
+
+class SurfnetCeremonyStepManagerFactoryTest extends TestCase
+{
+    private SurfnetCeremonyStepManagerFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new SurfnetCeremonyStepManagerFactory();
+    }
+
+    public function test_creation_ceremony_without_mds_has_expected_steps(): void
+    {
+        $manager = $this->factory->creationCeremony();
+        $stepClasses = $this->getStepClasses($manager);
+
+        $this->assertSame([
+            CheckClientDataCollectorType::class,
+            CheckChallenge::class,
+            CheckOrigin::class,
+            CheckTopOrigin::class,
+            CheckRelyingPartyIdIdHash::class,
+            CheckUserWasPresent::class,
+            CheckUserVerification::class,
+            CheckNoBackupEligibility::class,
+            CheckAlgorithm::class,
+            CheckExtensions::class,
+            CheckAttestationFormatIsKnownAndValid::class,
+            CheckHasAttestedCredentialData::class,
+            CheckMetadataStatement::class,
+            CheckCredentialId::class,
+            CheckAttestationIsNotNone::class,
+        ], $stepClasses);
+    }
+
+    public function test_creation_ceremony_with_mds_has_exact_expected_steps(): void
+    {
+        $this->factory->enableMetadataStatementSupport(
+            $this->createMock(MetadataStatementRepository::class),
+            $this->createMock(StatusReportRepository::class),
+            $this->createMock(CertificateChainValidator::class)
+        );
+
+        $manager = $this->factory->creationCeremony();
+        $stepClasses = $this->getStepClasses($manager);
+
+        $this->assertSame([
+            CheckClientDataCollectorType::class,
+            CheckChallenge::class,
+            CheckOrigin::class,
+            CheckTopOrigin::class,
+            CheckRelyingPartyIdIdHash::class,
+            CheckUserWasPresent::class,
+            CheckUserVerification::class,
+            CheckNoBackupEligibility::class,
+            CheckAlgorithm::class,
+            CheckExtensions::class,
+            CheckAttestationFormatIsKnownAndValid::class,
+            CheckHasAttestedCredentialData::class,
+            CheckMetadataStatement::class,
+            CheckCredentialId::class,
+            CheckAttestationIsNotNone::class,
+            CheckHardwareKeyProtection::class,
+            CheckFidoCertified::class,
+        ], $stepClasses);
+    }
+
+    public function test_creation_ceremony_does_not_include_backup_bits_consistent(): void
+    {
+        $manager = $this->factory->creationCeremony();
+        $stepClasses = $this->getStepClasses($manager);
+
+        $this->assertNotContains(CheckBackupBitsAreConsistent::class, $stepClasses);
+    }
+
+    public function test_request_ceremony_has_expected_steps(): void
+    {
+        $manager = $this->factory->requestCeremony();
+        $stepClasses = $this->getStepClasses($manager);
+
+        $this->assertSame([
+            CheckAllowedCredentialList::class,
+            CheckUserHandle::class,
+            CheckClientDataCollectorType::class,
+            CheckChallenge::class,
+            CheckOrigin::class,
+            CheckTopOrigin::class,
+            CheckRelyingPartyIdIdHash::class,
+            CheckUserWasPresent::class,
+            CheckUserVerification::class,
+            CheckBackupBitsAreConsistent::class,
+            CheckExtensions::class,
+            CheckSignature::class,
+            CheckCounter::class,
+        ], $stepClasses);
+    }
+
+    public function test_request_ceremony_does_not_include_registration_steps(): void
+    {
+        $manager = $this->factory->requestCeremony();
+        $stepClasses = $this->getStepClasses($manager);
+
+        $this->assertNotContains(CheckAttestationIsNotNone::class, $stepClasses);
+        $this->assertNotContains(CheckNoBackupEligibility::class, $stepClasses);
+        $this->assertNotContains(CheckHardwareKeyProtection::class, $stepClasses);
+        $this->assertNotContains(CheckFidoCertified::class, $stepClasses);
+    }
+
+    /** @return string[] */
+    private function getStepClasses(CeremonyStepManager $manager): array
+    {
+        $reflection = new ReflectionClass($manager);
+        $property = $reflection->getProperty('steps');
+        $property->setAccessible(true);
+        $steps = $property->getValue($manager);
+
+        return array_map(fn($step) => get_class($step), $steps);
+    }
+}

--- a/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
+++ b/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
@@ -56,25 +56,15 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->factory = new SurfnetCeremonyStepManagerFactory();
-    }
-
-    public function test_creation_ceremony_throws_without_mds(): void
-    {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('MDS must be configured');
-
-        $this->factory->creationCeremony();
+        $this->factory = new SurfnetCeremonyStepManagerFactory(
+            $this->createMock(MetadataStatementRepository::class),
+            $this->createMock(StatusReportRepository::class),
+            $this->createMock(CertificateChainValidator::class),
+        );
     }
 
     public function test_creation_ceremony_with_mds_has_exact_expected_steps(): void
     {
-        $this->factory->enableMetadataStatementSupport(
-            $this->createMock(MetadataStatementRepository::class),
-            $this->createMock(StatusReportRepository::class),
-            $this->createMock(CertificateChainValidator::class)
-        );
-
         $manager = $this->factory->creationCeremony();
         $stepClasses = $this->getStepClasses($manager);
 
@@ -101,12 +91,6 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
 
     public function test_creation_ceremony_does_not_include_backup_bits_consistent(): void
     {
-        $this->factory->enableMetadataStatementSupport(
-            $this->createMock(\Webauthn\MetadataService\MetadataStatementRepository::class),
-            $this->createMock(\Webauthn\MetadataService\StatusReportRepository::class),
-            $this->createMock(\Webauthn\MetadataService\CertificateChain\CertificateChainValidator::class)
-        );
-
         $manager = $this->factory->creationCeremony();
         $stepClasses = $this->getStepClasses($manager);
 

--- a/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
+++ b/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
@@ -22,10 +22,13 @@ namespace Test\Unit\CeremonyStep;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckAttestationIsNotNone;
 use Surfnet\Webauthn\CeremonyStep\CheckFidoCertified;
 use Surfnet\Webauthn\CeremonyStep\CheckHardwareKeyProtection;
 use Surfnet\Webauthn\CeremonyStep\CheckNoBackupEligibility;
+use Surfnet\Webauthn\CeremonyStep\LogAuthenticationData;
+use Surfnet\Webauthn\CeremonyStep\LogRegistrationData;
 use Surfnet\Webauthn\CeremonyStep\SurfnetCeremonyStepManagerFactory;
 use Webauthn\CeremonyStep\CeremonyStepManager;
 use Webauthn\CeremonyStep\CheckAlgorithm;
@@ -57,6 +60,7 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->factory = new SurfnetCeremonyStepManagerFactory(
+            new NullLogger(),
             $this->createMock(MetadataStatementRepository::class),
             $this->createMock(StatusReportRepository::class),
             $this->createMock(CertificateChainValidator::class),
@@ -69,6 +73,7 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
         $stepClasses = $this->getStepClasses($manager);
 
         $this->assertSame([
+            LogRegistrationData::class,
             CheckClientDataCollectorType::class,
             CheckChallenge::class,
             CheckOrigin::class,
@@ -103,6 +108,7 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
         $stepClasses = $this->getStepClasses($manager);
 
         $this->assertSame([
+            LogAuthenticationData::class,
             CheckAllowedCredentialList::class,
             CheckUserHandle::class,
             CheckClientDataCollectorType::class,

--- a/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
+++ b/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
@@ -59,28 +59,12 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
         $this->factory = new SurfnetCeremonyStepManagerFactory();
     }
 
-    public function test_creation_ceremony_without_mds_has_expected_steps(): void
+    public function test_creation_ceremony_throws_without_mds(): void
     {
-        $manager = $this->factory->creationCeremony();
-        $stepClasses = $this->getStepClasses($manager);
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('MDS must be configured');
 
-        $this->assertSame([
-            CheckClientDataCollectorType::class,
-            CheckChallenge::class,
-            CheckOrigin::class,
-            CheckTopOrigin::class,
-            CheckRelyingPartyIdIdHash::class,
-            CheckUserWasPresent::class,
-            CheckUserVerification::class,
-            CheckNoBackupEligibility::class,
-            CheckAlgorithm::class,
-            CheckExtensions::class,
-            CheckAttestationFormatIsKnownAndValid::class,
-            CheckHasAttestedCredentialData::class,
-            CheckMetadataStatement::class,
-            CheckCredentialId::class,
-            CheckAttestationIsNotNone::class,
-        ], $stepClasses);
+        $this->factory->creationCeremony();
     }
 
     public function test_creation_ceremony_with_mds_has_exact_expected_steps(): void
@@ -117,6 +101,12 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
 
     public function test_creation_ceremony_does_not_include_backup_bits_consistent(): void
     {
+        $this->factory->enableMetadataStatementSupport(
+            $this->createMock(\Webauthn\MetadataService\MetadataStatementRepository::class),
+            $this->createMock(\Webauthn\MetadataService\StatusReportRepository::class),
+            $this->createMock(\Webauthn\MetadataService\CertificateChain\CertificateChainValidator::class)
+        );
+
         $manager = $this->factory->creationCeremony();
         $stepClasses = $this->getStepClasses($manager);
 

--- a/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
+++ b/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
@@ -89,11 +89,11 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
             CheckNoBackupEligibility::class,
             CheckAlgorithm::class,
             CheckExtensions::class,
+            CheckAttestationIsNotNone::class,
             CheckAttestationFormatIsKnownAndValid::class,
             CheckHasAttestedCredentialData::class,
             CheckMetadataStatement::class,
             CheckCredentialId::class,
-            CheckAttestationIsNotNone::class,
             CheckHardwareKeyProtection::class,
             CheckFidoCertified::class,
         ], $stepClasses);


### PR DESCRIPTION
Replace the vendor CeremonyStepManagerFactory with an explicit, controlled implementation. Registration now rejects TYPE_NONE attestation, requires hardware key protection, requires FIDO certification, and blocks backup-eligible (multi-device/passkey) credentials. Both ceremony step lists are explicit so future library upgrades cannot silently add steps.

Status reports are sorted by effectiveDate before evaluation so the most recent report is always used regardless of repository ordering.