### PR TITLE
 Make authenticator selection criteria explicit and configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 - Restrict registration to cross-platform (hardware-bound) authenticators only
 - Make authenticator_attachment, user_verification, and attestation_conveyance configurable via parameters.yaml
 
+### Upgrade instructions
+The following parameters are required and must be added to `parameters.yaml`:
+```yaml
+webauthn_authenticator_attachment: 'cross-platform'
+webauthn_registration_user_verification: 'preferred'
+webauthn_attestation_conveyance: 'direct'
+```
+See `config/openconext/parameters.yaml.dist` for reference values and `\Webauthn\AuthenticatorSelectionCriteria` for available options.
+
 ## 2.1.0
 - Upgrade to Symfony 7.4 LTS
 - Remove EOL sensiolabs/security-checker configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Restrict registration to cross-platform (hardware-bound) authenticators only
+- Make authenticator_attachment, user_verification, and attestation_conveyance configurable via parameters.yaml
+
 ## 2.1.0
 - Upgrade to Symfony 7.4 LTS
 - Remove EOL sensiolabs/security-checker configuration

--- a/config/openconext/parameters.yaml.dist
+++ b/config/openconext/parameters.yaml.dist
@@ -23,6 +23,10 @@ parameters:
     webauthn_name: OpenConext DEV Environment
     webauthn_logo: 'https://openconext.org/wp-content/uploads/2016/11/openconext_logo-med.png'
 
+    webauthn_authenticator_attachment: 'cross-platform'
+    webauthn_registration_user_verification: 'preferred'
+    webauthn_attestation_conveyance: 'direct'
+
     fido2_jwt_mds_blob_file_name: '%kernel.project_dir%/config/openconext/mds/blob.jwt'
     fido2_jwt_mds_root_certificate_file_name: '%kernel.project_dir%/config/openconext/mds/root.crt'
     fido2_mds_cache_dir: '%kernel.project_dir%/var/mds/'

--- a/config/openconext/parameters.yaml.dist
+++ b/config/openconext/parameters.yaml.dist
@@ -23,6 +23,8 @@ parameters:
     webauthn_name: OpenConext DEV Environment
     webauthn_logo: 'https://openconext.org/wp-content/uploads/2016/11/openconext_logo-med.png'
 
+    # WebAuthn authenticator selection criteria.
+    # See \Webauthn\AuthenticatorSelectionCriteria for available option values.
     webauthn_authenticator_attachment: 'cross-platform'
     webauthn_registration_user_verification: 'preferred'
     webauthn_attestation_conveyance: 'direct'

--- a/config/packages/webauthn.yaml
+++ b/config/packages/webauthn.yaml
@@ -13,12 +13,12 @@ webauthn:
             challenge_length: 64
             timeout: 60000
             authenticator_selection_criteria:
-                authenticator_attachment: !php/const Webauthn\AuthenticatorSelectionCriteria::AUTHENTICATOR_ATTACHMENT_NO_PREFERENCE
+                authenticator_attachment: '%webauthn_authenticator_attachment%'
                 resident_key: !php/const Webauthn\AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_NO_PREFERENCE
                 require_resident_key: false
-                user_verification: !php/const Webauthn\AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_PREFERRED
+                user_verification: '%webauthn_registration_user_verification%'
             #  this is needed for SURFsecureID as we want to whitelist authenticators by vendor/certification (default is none)
-            attestation_conveyance: !php/const Webauthn\PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_DIRECT
+            attestation_conveyance: '%webauthn_attestation_conveyance%'
     request_profiles:
         default:
             challenge_length: 64


### PR DESCRIPTION
Restrict registration to cross-platform (hardware-bound) tokens by
changing authenticator_attachment from NO_PREFERENCE to cross-platform.
Expose authenticator_attachment, user_verification, and
attestation_conveyance as operator-configurable parameters in
parameters.yaml so values can be changed without touching PHP constants