### PR TITLE
feat: add structured logging to registration ceremony steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ yarn-error.log
 ###> phpunit/phpunit ###
 /phpunit.xml
 .phpunit.result.cache
+ci/qa/.phpunit.cache/
 ###< phpunit/phpunit ###
 
 ###> squizlabs/php_codesniffer ###

--- a/ci/qa/phpstan-baseline.neon
+++ b/ci/qa/phpstan-baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: ../../src/Controller/ExceptionController.php
 
 		-
-			message: '#^Property Surfnet\\Webauthn\\Entity\\PublicKeyCredentialSource\:\:\$fmt is never read, only written\.$#'
-			identifier: property.onlyWritten
-			count: 1
-			path: ../../src/Entity/PublicKeyCredentialSource.php
-
-		-
 			message: '#^Class Surfnet\\Webauthn\\Entity\\User has an uninitialized readonly property \$displayName\. Assign it in the constructor\.$#'
 			identifier: property.uninitializedReadonly
 			count: 1

--- a/src/CeremonyStep/CheckAttestationIsNotNone.php
+++ b/src/CeremonyStep/CheckAttestationIsNotNone.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Surfnet\Webauthn\CeremonyStep;
 
+use Psr\Log\LoggerInterface;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -31,6 +32,10 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckAttestationIsNotNone implements CeremonyStep
 {
+    public function __construct(private readonly LoggerInterface $logger)
+    {
+    }
+
     public function process(
         PublicKeyCredentialSource $publicKeyCredentialSource,
         AuthenticatorAssertionResponse|AuthenticatorAttestationResponse $authenticatorResponse,
@@ -42,12 +47,20 @@ final class CheckAttestationIsNotNone implements CeremonyStep
             return;
         }
 
+        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
         $attestationType = $authenticatorResponse->attestationObject->attStmt->type;
+
+        $this->logger->info('Checking attestation type is not none', [
+            'registrationId' => $registrationId,
+            'attestationType' => $attestationType,
+        ]);
 
         if ($attestationType === AttestationStatement::TYPE_NONE) {
             throw AuthenticatorResponseVerificationException::create(
                 'Attestation is required. TYPE_NONE responses are not accepted.'
             );
         }
+
+        $this->logger->info('Attestation type accepted', ['registrationId' => $registrationId]);
     }
 }

--- a/src/CeremonyStep/CheckAttestationIsNotNone.php
+++ b/src/CeremonyStep/CheckAttestationIsNotNone.php
@@ -32,6 +32,7 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckAttestationIsNotNone implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -47,7 +48,7 @@ final class CheckAttestationIsNotNone implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $attestationType = $authenticatorResponse->attestationObject->attStmt->type;
 
         $this->logger->info('Checking attestation type is not none', [

--- a/src/CeremonyStep/CheckFidoCertified.php
+++ b/src/CeremonyStep/CheckFidoCertified.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace Surfnet\Webauthn\CeremonyStep;
 
 use LogicException;
+use Psr\Log\LoggerInterface;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
@@ -48,6 +49,7 @@ final class CheckFidoCertified implements CeremonyStep
 
     public function __construct(
         private readonly StatusReportRepository $statusReportRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -67,8 +69,15 @@ final class CheckFidoCertified implements CeremonyStep
             return;
         }
 
+        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $reports = $this->statusReportRepository->findStatusReportsByAAGUID($aaguid);
+
+        $this->logger->info('Checking FIDO certification status', [
+            'registrationId' => $registrationId,
+            'aaguid' => $aaguid,
+            'statusReportCount' => count($reports),
+        ]);
 
         if ($reports === []) {
             throw AuthenticatorResponseVerificationException::create(
@@ -78,6 +87,13 @@ final class CheckFidoCertified implements CeremonyStep
 
         $mostRecent = $this->mostRecentReport($reports);
 
+        $this->logger->info('Most recent FIDO status report', [
+            'registrationId' => $registrationId,
+            'aaguid' => $aaguid,
+            'status' => $mostRecent->status,
+            'effectiveDate' => $mostRecent->effectiveDate,
+        ]);
+
         if (!in_array($mostRecent->status, self::FIDO_CERTIFIED_STATUSES, true)) {
             throw AuthenticatorResponseVerificationException::create(
                 sprintf(
@@ -86,6 +102,8 @@ final class CheckFidoCertified implements CeremonyStep
                 )
             );
         }
+
+        $this->logger->info('FIDO certification check passed', ['registrationId' => $registrationId]);
     }
 
     /**

--- a/src/CeremonyStep/CheckFidoCertified.php
+++ b/src/CeremonyStep/CheckFidoCertified.php
@@ -35,6 +35,8 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckFidoCertified implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     private const FIDO_CERTIFIED_STATUSES = [
         AuthenticatorStatus::FIDO_CERTIFIED,
         AuthenticatorStatus::FIDO_CERTIFIED_L1,
@@ -69,7 +71,7 @@ final class CheckFidoCertified implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $reports = $this->statusReportRepository->findStatusReportsByAAGUID($aaguid);
 

--- a/src/CeremonyStep/CheckHardwareKeyProtection.php
+++ b/src/CeremonyStep/CheckHardwareKeyProtection.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Surfnet\Webauthn\CeremonyStep;
 
+use Psr\Log\LoggerInterface;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
@@ -39,6 +40,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
 
     public function __construct(
         private readonly MetadataStatementRepository $metadataStatementRepository,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -58,6 +60,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
             return;
         }
 
+        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $metadataStatement = $this->metadataStatementRepository->findOneByAAGUID($aaguid);
 
@@ -65,8 +68,19 @@ final class CheckHardwareKeyProtection implements CeremonyStep
         // TYPE_NONE attestation is already rejected by CheckAttestationIsNotNone,
         // so this only affects authenticators that attest but are absent from the FIDO MDS.
         if ($metadataStatement === null) {
+            $this->logger->info('No MDS metadata statement found for AAGUID, skipping key protection check', [
+                'registrationId' => $registrationId,
+                'aaguid' => $aaguid,
+            ]);
             return;
         }
+
+        $this->logger->info('MDS metadata statement found for authenticator', [
+            'registrationId' => $registrationId,
+            'aaguid' => $aaguid,
+            'description' => isset($metadataStatement->description) ? $metadataStatement->description : null,
+            'keyProtection' => $metadataStatement->keyProtection,
+        ]);
 
         if (count(array_intersect($metadataStatement->keyProtection, self::ALLOWED_KEY_PROTECTION)) === 0) {
             throw AuthenticatorResponseVerificationException::create(
@@ -76,5 +90,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
                 )
             );
         }
+
+        $this->logger->info('Key protection check passed', ['registrationId' => $registrationId]);
     }
 }

--- a/src/CeremonyStep/CheckHardwareKeyProtection.php
+++ b/src/CeremonyStep/CheckHardwareKeyProtection.php
@@ -33,6 +33,8 @@ use Webauthn\PublicKeyCredentialSource;
 
 final class CheckHardwareKeyProtection implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     private const ALLOWED_KEY_PROTECTION = [
         MetadataStatement::KEY_PROTECTION_HARDWARE,
         MetadataStatement::KEY_PROTECTION_SECURE_ELEMENT,
@@ -60,7 +62,7 @@ final class CheckHardwareKeyProtection implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $aaguid = $attestedCredentialData->aaguid->__toString();
         $metadataStatement = $this->metadataStatementRepository->findOneByAAGUID($aaguid);
 

--- a/src/CeremonyStep/CheckNoBackupEligibility.php
+++ b/src/CeremonyStep/CheckNoBackupEligibility.php
@@ -36,6 +36,8 @@ use Webauthn\PublicKeyCredentialSource;
  */
 final class CheckNoBackupEligibility implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -51,7 +53,7 @@ final class CheckNoBackupEligibility implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
         $authData = $authenticatorResponse->attestationObject->authData;
 
         $this->logger->info('Checking backup eligibility', [

--- a/src/CeremonyStep/LogAuthenticationData.php
+++ b/src/CeremonyStep/LogAuthenticationData.php
@@ -21,21 +21,23 @@ declare(strict_types=1);
 namespace Surfnet\Webauthn\CeremonyStep;
 
 use Psr\Log\LoggerInterface;
+use Surfnet\Webauthn\Entity\PublicKeyCredentialSource as SurfnetPublicKeyCredentialSource;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
-use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 
 /**
- * Rejects credentials that are backup-eligible (i.e. can be synced across devices / passkeys).
- * This is the runtime proxy for the MDS multiDeviceCredentialSupport field, which is not
- * exposed in webauthn-lib v5.
+ * First step in the request ceremony. Logs the AAGUID of the authenticating credential.
+ * Warns when the credential has a null AAGUID (CTAP1/U2F legacy token).
+ * Never throws — purely observational.
  */
-final class CheckNoBackupEligibility implements CeremonyStep
+final class LogAuthenticationData implements CeremonyStep
 {
+    private const NULL_AAGUID = '00000000-0000-0000-0000-000000000000';
+
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -47,24 +49,28 @@ final class CheckNoBackupEligibility implements CeremonyStep
         ?string $userHandle,
         string $host
     ): void {
-        if (!$authenticatorResponse instanceof AuthenticatorAttestationResponse) {
+        if (!$authenticatorResponse instanceof AuthenticatorAssertionResponse) {
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
-        $authData = $authenticatorResponse->attestationObject->authData;
+        $aaguid = $publicKeyCredentialSource->aaguid->__toString();
+        $fmt = $publicKeyCredentialSource instanceof SurfnetPublicKeyCredentialSource
+            ? $publicKeyCredentialSource->getFmt()
+            : null;
 
-        $this->logger->info('Checking backup eligibility', [
-            'registrationId' => $registrationId,
-            'isBackupEligible' => $authData->isBackupEligible(),
-        ]);
-
-        if ($authData->isBackupEligible()) {
-            throw AuthenticatorResponseVerificationException::create(
-                'Multi-device credentials are not accepted. The authenticator must not be backup-eligible.'
-            );
+        if ($aaguid === self::NULL_AAGUID) {
+            $this->logger->warning('Authentication with legacy token: null AAGUID indicates CTAP1/U2F credential registered before FIDO MDS enforcement', [
+                'aaguid' => $aaguid,
+                'fmt' => $fmt,
+                'userHandle' => $userHandle,
+            ]);
+            return;
         }
 
-        $this->logger->info('Backup eligibility check passed', ['registrationId' => $registrationId]);
+        $this->logger->info('Authentication ceremony started', [
+            'aaguid' => $aaguid,
+            'fmt' => $fmt,
+            'userHandle' => $userHandle,
+        ]);
     }
 }

--- a/src/CeremonyStep/LogRegistrationData.php
+++ b/src/CeremonyStep/LogRegistrationData.php
@@ -34,6 +34,8 @@ use Webauthn\PublicKeyCredentialSource;
  */
 final class LogRegistrationData implements CeremonyStep
 {
+    use RegistrationIdFromChallenge;
+
     public function __construct(private readonly LoggerInterface $logger)
     {
     }
@@ -49,7 +51,7 @@ final class LogRegistrationData implements CeremonyStep
             return;
         }
 
-        $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+        $registrationId = $this->registrationId($publicKeyCredentialOptions->challenge);
 
         $attestedCredentialData = $authenticatorResponse->attestationObject->authData->attestedCredentialData;
         $aaguid = $attestedCredentialData?->aaguid->__toString() ?? '00000000-0000-0000-0000-000000000000';

--- a/src/CeremonyStep/LogRegistrationData.php
+++ b/src/CeremonyStep/LogRegistrationData.php
@@ -24,17 +24,15 @@ use Psr\Log\LoggerInterface;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\CeremonyStep\CeremonyStep;
-use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialSource;
 
 /**
- * Rejects credentials that are backup-eligible (i.e. can be synced across devices / passkeys).
- * This is the runtime proxy for the MDS multiDeviceCredentialSupport field, which is not
- * exposed in webauthn-lib v5.
+ * First step in the creation ceremony. Logs the raw attestation data for audit/debugging purposes.
+ * Never throws — purely observational.
  */
-final class CheckNoBackupEligibility implements CeremonyStep
+final class LogRegistrationData implements CeremonyStep
 {
     public function __construct(private readonly LoggerInterface $logger)
     {
@@ -52,19 +50,25 @@ final class CheckNoBackupEligibility implements CeremonyStep
         }
 
         $registrationId = sodium_bin2base64($publicKeyCredentialOptions->challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
-        $authData = $authenticatorResponse->attestationObject->authData;
 
-        $this->logger->info('Checking backup eligibility', [
+        $attestedCredentialData = $authenticatorResponse->attestationObject->authData->attestedCredentialData;
+        $aaguid = $attestedCredentialData?->aaguid->__toString() ?? '00000000-0000-0000-0000-000000000000';
+
+        $this->logger->info('Registration ceremony started', [
             'registrationId' => $registrationId,
-            'isBackupEligible' => $authData->isBackupEligible(),
+            'aaguid' => $aaguid,
+            'attestationFormat' => $authenticatorResponse->attestationObject->attStmt->fmt,
+            'clientDataType' => $authenticatorResponse->clientDataJSON->type,
+            'origin' => $authenticatorResponse->clientDataJSON->origin,
         ]);
 
-        if ($authData->isBackupEligible()) {
-            throw AuthenticatorResponseVerificationException::create(
-                'Multi-device credentials are not accepted. The authenticator must not be backup-eligible.'
-            );
-        }
-
-        $this->logger->info('Backup eligibility check passed', ['registrationId' => $registrationId]);
+        $this->logger->info('Registration ceremony raw attestation data', [
+            'registrationId' => $registrationId,
+            'clientDataJSON' => $authenticatorResponse->clientDataJSON->rawData,
+            'attestationObject' => sodium_bin2base64(
+                $authenticatorResponse->attestationObject->rawAttestationObject,
+                SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING
+            ),
+        ]);
     }
 }

--- a/src/CeremonyStep/RegistrationIdFromChallenge.php
+++ b/src/CeremonyStep/RegistrationIdFromChallenge.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\CeremonyStep;
+
+trait RegistrationIdFromChallenge
+{
+    private function registrationId(string $challenge): string
+    {
+        return sodium_bin2base64($challenge, SODIUM_BASE64_VARIANT_URLSAFE_NO_PADDING);
+    }
+}

--- a/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
+++ b/src/CeremonyStep/SurfnetCeremonyStepManagerFactory.php
@@ -23,6 +23,7 @@ namespace Surfnet\Webauthn\CeremonyStep;
 use Cose\Algorithm\Manager;
 use Cose\Algorithm\Signature\ECDSA\ES256;
 use Cose\Algorithm\Signature\RSA\RS256;
+use Psr\Log\LoggerInterface;
 use Webauthn\AttestationStatement\AttestationStatementSupportManager;
 use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
 use Webauthn\AuthenticationExtensions\ExtensionOutputCheckerHandler;
@@ -81,6 +82,7 @@ final class SurfnetCeremonyStepManagerFactory
     private ExtensionOutputCheckerHandler $extensionOutputCheckerHandler;
 
     public function __construct(
+        private readonly LoggerInterface $logger,
         private readonly MetadataStatementRepository $metadataStatementRepository,
         private readonly StatusReportRepository $statusReportRepository,
         private readonly CertificateChainValidator $certificateChainValidator,
@@ -171,6 +173,7 @@ final class SurfnetCeremonyStepManagerFactory
             : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains);
 
         return new CeremonyStepManager([
+            new LogRegistrationData($this->logger),
             new CheckClientDataCollectorType(),
             new CheckChallenge(),
             $originStep,
@@ -178,16 +181,16 @@ final class SurfnetCeremonyStepManagerFactory
             new CheckRelyingPartyIdIdHash(),
             new CheckUserWasPresent(),
             new CheckUserVerification(),
-            new CheckNoBackupEligibility(),
+            new CheckNoBackupEligibility($this->logger),
             new CheckAlgorithm(),
             new CheckExtensions($this->extensionOutputCheckerHandler),
-            new CheckAttestationIsNotNone(),
+            new CheckAttestationIsNotNone($this->logger),
             new CheckAttestationFormatIsKnownAndValid($this->attestationStatementSupportManager),
             new CheckHasAttestedCredentialData(),
             $metadataStatementChecker,
             new CheckCredentialId(),
-            new CheckHardwareKeyProtection($this->metadataStatementRepository),
-            new CheckFidoCertified($this->statusReportRepository),
+            new CheckHardwareKeyProtection($this->metadataStatementRepository, $this->logger),
+            new CheckFidoCertified($this->statusReportRepository, $this->logger),
         ]);
     }
 
@@ -198,6 +201,7 @@ final class SurfnetCeremonyStepManagerFactory
             : new CheckAllowedOrigins($this->allowedOrigins, $this->allowSubdomains);
 
         return new CeremonyStepManager([
+            new LogAuthenticationData($this->logger),
             new CheckAllowedCredentialList(),
             new CheckUserHandle(),
             new CheckClientDataCollectorType(),

--- a/src/Entity/PublicKeyCredentialSource.php
+++ b/src/Entity/PublicKeyCredentialSource.php
@@ -79,4 +79,9 @@ class PublicKeyCredentialSource extends BasePublicKeyCredentialSource
     {
         return $this->id;
     }
+
+    public function getFmt(): string
+    {
+        return $this->fmt;
+    }
 }

--- a/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
+++ b/tests/Integration/CeremonyStep/FullRegistrationCeremonyTest.php
@@ -42,6 +42,7 @@ use Webauthn\MetadataService\Statement\AuthenticatorStatus;
 use Webauthn\MetadataService\Statement\MetadataStatement;
 use Webauthn\MetadataService\Statement\StatusReport;
 use Webauthn\MetadataService\StatusReportRepository;
+use Psr\Log\NullLogger;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRpEntity;
@@ -304,7 +305,7 @@ class FullRegistrationCeremonyTest extends TestCase
             }
         };
 
-        $factory = new SurfnetCeremonyStepManagerFactory($mdsRepo, $statusRepo, $certChainValidator);
+        $factory = new SurfnetCeremonyStepManagerFactory(new NullLogger(), $mdsRepo, $statusRepo, $certChainValidator);
         $factory->setAllowedOrigins([self::ORIGIN]);
         $factory->setAttestationStatementSupportManager(
             new AttestationStatementSupportManager([

--- a/tests/Unit/CeremonyStep/CheckAttestationIsNotNoneTest.php
+++ b/tests/Unit/CeremonyStep/CheckAttestationIsNotNoneTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckAttestationIsNotNone;
 use Webauthn\AttestationStatement\AttestationStatement;
 use Webauthn\AuthenticatorAssertionResponse;
@@ -32,7 +33,7 @@ class CheckAttestationIsNotNoneTest extends AbstractCeremonyStepTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->step = new CheckAttestationIsNotNone();
+        $this->step = new CheckAttestationIsNotNone(new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
+++ b/tests/Unit/CeremonyStep/CheckFidoCertifiedTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckFidoCertified;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
@@ -36,7 +37,7 @@ class CheckFidoCertifiedTest extends AbstractCeremonyStepTestCase
     {
         parent::setUp();
         $this->repository = $this->createMock(StatusReportRepository::class);
-        $this->step = new CheckFidoCertified($this->repository);
+        $this->step = new CheckFidoCertified($this->repository, new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
+++ b/tests/Unit/CeremonyStep/CheckHardwareKeyProtectionTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckHardwareKeyProtection;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
@@ -35,7 +36,7 @@ class CheckHardwareKeyProtectionTest extends AbstractCeremonyStepTestCase
     {
         parent::setUp();
         $this->repository = $this->createMock(MetadataStatementRepository::class);
-        $this->step = new CheckHardwareKeyProtection($this->repository);
+        $this->step = new CheckHardwareKeyProtection($this->repository, new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/CheckNoBackupEligibilityTest.php
+++ b/tests/Unit/CeremonyStep/CheckNoBackupEligibilityTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Test\Unit\CeremonyStep;
 
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckNoBackupEligibility;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
@@ -31,7 +32,7 @@ class CheckNoBackupEligibilityTest extends AbstractCeremonyStepTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->step = new CheckNoBackupEligibility();
+        $this->step = new CheckNoBackupEligibility(new NullLogger());
     }
 
     public function test_skips_assertion_response(): void

--- a/tests/Unit/CeremonyStep/LogAuthenticationDataTest.php
+++ b/tests/Unit/CeremonyStep/LogAuthenticationDataTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Surfnet\Webauthn\CeremonyStep\LogAuthenticationData;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\AttestedCredentialData;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\PublicKeyCredentialSource;
+
+class LogAuthenticationDataTest extends AbstractCeremonyStepTestCase
+{
+    private LogAuthenticationData $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->step = new LogAuthenticationData(new NullLogger());
+    }
+
+    public function test_skips_attestation_response_without_logging(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+        $logger->expects($this->never())->method('warning');
+
+        $step = new LogAuthenticationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_info_for_known_aaguid(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info');
+        $logger->expects($this->never())->method('warning');
+
+        $credentialSource = $this->credentialSourceWithAaguid('550e8400-e29b-41d4-a716-446655440000');
+
+        $step = new LogAuthenticationData($logger);
+        $step->process(
+            $credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_warning_for_null_aaguid(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+        $logger->expects($this->once())->method('warning');
+
+        $credentialSource = $this->credentialSourceWithAaguid('00000000-0000-0000-0000-000000000000');
+
+        $step = new LogAuthenticationData($logger);
+        $step->process(
+            $credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_never_throws(): void
+    {
+        $credentialSource = $this->credentialSourceWithAaguid('00000000-0000-0000-0000-000000000000');
+
+        $this->step->process(
+            $credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function credentialSourceWithAaguid(string $uuid): PublicKeyCredentialSource
+    {
+        return PublicKeyCredentialSource::create(
+            'credential-id',
+            'public-key',
+            [],
+            'basic',
+            new \Webauthn\TrustPath\EmptyTrustPath(),
+            Uuid::fromString($uuid),
+            'public-key-bytes',
+            'user-handle',
+            0,
+        );
+    }
+}

--- a/tests/Unit/CeremonyStep/LogRegistrationDataTest.php
+++ b/tests/Unit/CeremonyStep/LogRegistrationDataTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Copyright 2026 SURFnet B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Test\Unit\CeremonyStep;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Surfnet\Webauthn\CeremonyStep\LogRegistrationData;
+use Webauthn\AuthenticatorAssertionResponse;
+
+class LogRegistrationDataTest extends AbstractCeremonyStepTestCase
+{
+    private LogRegistrationData $step;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->step = new LogRegistrationData(new NullLogger());
+    }
+
+    public function test_skips_assertion_response_without_logging(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('info');
+
+
+        $step = new LogRegistrationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->createMock(AuthenticatorAssertionResponse::class),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_info_for_attestation_response(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('info');
+
+        $step = new LogRegistrationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_logs_raw_attestation_data_at_info(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))->method('info');
+
+        $step = new LogRegistrationData($logger);
+        $step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+    }
+
+    public function test_never_throws(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse($this->makeAttestedCredentialData()),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_never_throws_without_attested_credential_data(): void
+    {
+        $this->step->process(
+            $this->credentialSource,
+            $this->buildAttestationResponse(),
+            $this->options,
+            null,
+            'example.com'
+        );
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
+++ b/tests/Unit/CeremonyStep/SurfnetCeremonyStepManagerFactoryTest.php
@@ -22,10 +22,13 @@ namespace Test\Unit\CeremonyStep;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Psr\Log\NullLogger;
 use Surfnet\Webauthn\CeremonyStep\CheckAttestationIsNotNone;
 use Surfnet\Webauthn\CeremonyStep\CheckFidoCertified;
 use Surfnet\Webauthn\CeremonyStep\CheckHardwareKeyProtection;
 use Surfnet\Webauthn\CeremonyStep\CheckNoBackupEligibility;
+use Surfnet\Webauthn\CeremonyStep\LogAuthenticationData;
+use Surfnet\Webauthn\CeremonyStep\LogRegistrationData;
 use Surfnet\Webauthn\CeremonyStep\SurfnetCeremonyStepManagerFactory;
 use Webauthn\CeremonyStep\CeremonyStepManager;
 use Webauthn\CeremonyStep\CheckAlgorithm;
@@ -57,6 +60,7 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->factory = new SurfnetCeremonyStepManagerFactory(
+            new NullLogger(),
             $this->createMock(MetadataStatementRepository::class),
             $this->createMock(StatusReportRepository::class),
             $this->createMock(CertificateChainValidator::class),
@@ -69,6 +73,7 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
         $stepClasses = $this->getStepClasses($manager);
 
         $this->assertSame([
+            LogRegistrationData::class,
             CheckClientDataCollectorType::class,
             CheckChallenge::class,
             CheckOrigin::class,
@@ -103,6 +108,7 @@ class SurfnetCeremonyStepManagerFactoryTest extends TestCase
         $stepClasses = $this->getStepClasses($manager);
 
         $this->assertSame([
+            LogAuthenticationData::class,
             CheckAllowedCredentialList::class,
             CheckUserHandle::class,
             CheckClientDataCollectorType::class,


### PR DESCRIPTION
Injects LoggerInterface into SurfnetCeremonyStepManagerFactory and all custom ceremony steps. Adds a new LogRegistrationData first step that logs AAGUID, attestation format, clientDataJSON, and raw attestationObject at the start of each creation ceremony.

Each custom step logs its check and result under a shared registrationId (challenge base64url) so a full registration flow is traceable by one ID.

The webauthn-lib validator logger is intentionally left as NullLogger; wiring it would dump full attestation objects at info level on every request.