### PR TITLE
Feature/log improvements

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -26,7 +26,7 @@ when@dev:
             main_syslog:
                 type: stream
                 path: php://stderr
-                level: error
+                level: info
                 channels: ["!event", "!doctrine", "!console"]
             console:
                 type: console
@@ -38,7 +38,7 @@ when@test:
             main_syslog:
                 type: stream
                 path: php://stderr
-                level: error
+                level: info
                 channels: ["!event", "!doctrine", "!deprecation", "!console"]
             console:
                 type: console

--- a/src/EventSubscriber/WebAuthnEventLogger.php
+++ b/src/EventSubscriber/WebAuthnEventLogger.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Surfnet\Webauthn\EventSubscriber;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Serializer\Encoder\JsonEncode;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\Bundle\Event\PublicKeyCredentialCreationOptionsCreatedEvent;
+
+final readonly class WebAuthnEventLogger implements EventSubscriberInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private SerializerInterface $serializer,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PublicKeyCredentialCreationOptionsCreatedEvent::class => 'onPublicKeyCredentialCreationOptionsCreated',
+        ];
+    }
+
+    public function onPublicKeyCredentialCreationOptionsCreated(
+        PublicKeyCredentialCreationOptionsCreatedEvent $event
+    ): void {
+        $json = $this->serializer->serialize(
+            $event->publicKeyCredentialCreationOptions,
+            JsonEncoder::FORMAT,
+        );
+
+        $this->logger->info('publicKeyCredentialCreationOptions', [
+            'options' => $json,
+        ]);
+    }
+}


### PR DESCRIPTION
* Fix logging not appearing in `docker logs` when running in dev mode
* Add an event listener for CredentialCreationOptionsCreatedEvent so we can log what it's sending to the client (just does a serialize to JSON of the event now and logs it)