### PR TITLE
fix: add missing timestamp to GlobalViewParameters::getRequestInforma…

### DIFF
--- a/src/GlobalViewParameters.php
+++ b/src/GlobalViewParameters.php
@@ -51,6 +51,7 @@ final readonly class GlobalViewParameters
         $metadata = $this->clientMetadataService->generateMetadata($this->request->getCurrentRequest());
         return [
             'supportEmail' => $this->supportEmail,
+            'timestamp' => $metadata['timestamp'],
             'hostname' => $metadata['hostname'],
             'ipAddress' => $metadata['ip_address'],
             'requestId' => $metadata['request_id'],


### PR DESCRIPTION
…tion()

Commit 92ff962 refactored error_table.html.twig to read all error table values from global_view_parameters.requestInformation.* instead of passed-in template variables. However, GlobalViewParameters.php was not updated in that commit, so the timestamp key was never forwarded from ClientMetadataService::generateMetadata() into getRequestInformation().

This caused a Twig error when visiting /registration:

  Key "timestamp" for sequence/mapping with keys "supportEmail, hostname,
  ipAddress, requestId, sari, userAgent" does not exist in
  partial/error_table.html.twig at line 6.